### PR TITLE
Add "Reduce Transparency" option

### DIFF
--- a/Cai/Cai/Models/CaiSettings.swift
+++ b/Cai/Cai/Models/CaiSettings.swift
@@ -21,6 +21,7 @@ class CaiSettings: ObservableObject {
         static let outputDestinations = "cai_outputDestinations"
         static let builtInModelPath = "cai_builtInModelPath"
         static let builtInSetupDone = "cai_builtInSetupDone"
+        static let reduceTransparency = "cai_reduceTransparency"
     }
 
     // MARK: - Model Provider
@@ -116,6 +117,11 @@ class CaiSettings: ObservableObject {
         }
     }
 
+    /// When true, uses a solid background instead of the translucent blur effect.
+    @Published var reduceTransparency: Bool {
+        didSet { defaults.set(reduceTransparency, forKey: Keys.reduceTransparency) }
+    }
+
     /// Actual port the built-in llama-server is running on (set by BuiltInLLM after start).
     /// Not persisted — defaults to 8690, updated at runtime.
     var builtInPort: Int = 8690
@@ -171,6 +177,7 @@ class CaiSettings: ObservableObject {
 
         self.builtInModelPath = defaults.string(forKey: Keys.builtInModelPath) ?? ""
         self.builtInSetupDone = defaults.bool(forKey: Keys.builtInSetupDone)
+        self.reduceTransparency = defaults.bool(forKey: Keys.reduceTransparency)
 
         let mapsRaw = defaults.string(forKey: Keys.mapsProvider) ?? MapsProvider.apple.rawValue
         self.mapsProvider = MapsProvider(rawValue: mapsRaw) ?? .apple

--- a/Cai/Cai/Views/ActionListWindow.swift
+++ b/Cai/Cai/Views/ActionListWindow.swift
@@ -113,7 +113,7 @@ struct ActionListWindow: View {
 
     var body: some View {
         ZStack(alignment: .top) {
-            VisualEffectBackground()
+            VisualEffectBackground(reduceTransparency: settings.reduceTransparency)
 
             if showDestinationsManagement {
                 DestinationsManagementView(

--- a/Cai/Cai/Views/OnboardingPermissionView.swift
+++ b/Cai/Cai/Views/OnboardingPermissionView.swift
@@ -4,6 +4,7 @@ import SwiftUI
 /// is not yet granted. Auto-dismisses once the user enables the permission.
 struct OnboardingPermissionView: View {
     @ObservedObject private var permissions = PermissionsManager.shared
+    @ObservedObject private var settings = CaiSettings.shared
 
     var body: some View {
         VStack(spacing: 0) {
@@ -62,7 +63,7 @@ struct OnboardingPermissionView: View {
             Spacer().frame(height: 20)
         }
         .frame(width: 320, height: 340)
-        .background(VisualEffectBackground(cornerRadius: 0))
+        .background(VisualEffectBackground(cornerRadius: 0, reduceTransparency: settings.reduceTransparency))
     }
 
     private func permissionRow(icon: String, text: String) -> some View {

--- a/Cai/Cai/Views/SettingsView.swift
+++ b/Cai/Cai/Views/SettingsView.swift
@@ -193,10 +193,16 @@ struct SettingsView: View {
 
                     // General
                     settingsSection(title: "General", icon: "gearshape") {
-                        Toggle("Launch at Login", isOn: $settings.launchAtLogin)
-                            .font(.system(size: 12))
-                            .foregroundColor(.caiTextPrimary)
-                            .accessibilityLabel("Launch Cai at login")
+                        VStack(alignment: .leading, spacing: 8) {
+                            Toggle("Launch at Login", isOn: $settings.launchAtLogin)
+                                .font(.system(size: 12))
+                                .foregroundColor(.caiTextPrimary)
+                                .accessibilityLabel("Launch Cai at login")
+                            Toggle("Reduce Transparency", isOn: $settings.reduceTransparency)
+                                .font(.system(size: 12))
+                                .foregroundColor(.caiTextPrimary)
+                                .accessibilityLabel("Use solid background instead of blur")
+                        }
                     }
 
                     // Hotkey reminder

--- a/Cai/Cai/Views/VisualEffectBackground.swift
+++ b/Cai/Cai/Views/VisualEffectBackground.swift
@@ -3,23 +3,37 @@ import SwiftUI
 /// NSVisualEffectView wrapper for SwiftUI — provides the translucent blur
 /// background similar to Raycast, Spotlight, and other system HUD windows.
 /// Masks the view with rounded corners so it matches the outer clipShape.
+///
+/// When `reduceTransparency` is true, uses a solid window background instead
+/// of the translucent blur effect.
 struct VisualEffectBackground: NSViewRepresentable {
     var cornerRadius: CGFloat = 20
+    var reduceTransparency: Bool = false
 
     func makeNSView(context: Context) -> NSVisualEffectView {
         let view = NSVisualEffectView()
-        view.material = .hudWindow
-        view.blendingMode = .behindWindow
-        view.state = .active
-        view.isEmphasized = true
-        view.wantsLayer = true
-        view.layer?.cornerRadius = cornerRadius
-        view.layer?.cornerCurve = .continuous
-        view.layer?.masksToBounds = true
+        configureView(view)
         return view
     }
 
     func updateNSView(_ nsView: NSVisualEffectView, context: Context) {
-        nsView.layer?.cornerRadius = cornerRadius
+        configureView(nsView)
+    }
+
+    private func configureView(_ view: NSVisualEffectView) {
+        if reduceTransparency {
+            view.material = .windowBackground
+            view.blendingMode = .withinWindow
+            view.state = .inactive
+        } else {
+            view.material = .hudWindow
+            view.blendingMode = .behindWindow
+            view.state = .active
+        }
+        view.isEmphasized = !reduceTransparency
+        view.wantsLayer = true
+        view.layer?.cornerRadius = cornerRadius
+        view.layer?.cornerCurve = .continuous
+        view.layer?.masksToBounds = true
     }
 }


### PR DESCRIPTION
Adds a toggle in Settings → General to swap the translucent blur for a solid background. Useful if you find the blur distracting or harder to read.

## What changed

- `CaiSettings.swift` — new `reduceTransparency` bool, persisted to UserDefaults
- `VisualEffectBackground.swift` — switches material/blending mode based on setting
- `ActionListWindow.swift` / `OnboardingPermissionView.swift` — pass the setting through
- `SettingsView.swift` — toggle in General section

## Notes

This PR was created with AI assistance (Claude) but I've personally tested and verified the changes.

All 60 tests pass.