### PR TITLE
Add paste-back for selected text

### DIFF
--- a/Cai/Cai/Models/ActionItem.swift
+++ b/Cai/Cai/Models/ActionItem.swift
@@ -9,6 +9,9 @@ struct ActionItem: Identifiable {
     let icon: String  // SF Symbol name
     let shortcut: Int
     let type: ActionType
+    /// Set by shortcut-driven actions where the user has opted in to
+    /// auto-pasting the LLM response back over their selection.
+    var autoReplaceSelection: Bool = false
 }
 
 enum ActionType {

--- a/Cai/Cai/Models/BuiltInDestinations.swift
+++ b/Cai/Cai/Models/BuiltInDestinations.swift
@@ -52,6 +52,19 @@ struct BuiltInDestinations {
         showInActionList: false
     )
 
+    /// Replaces the user's current selection in the source app by simulating Cmd+V
+    /// after Cai hands focus back. Off by default so users opt in, since the
+    /// destructive overwrite behavior surprises people the first time.
+    static let pasteBack = OutputDestination(
+        id: UUID(uuidString: "00000000-0000-0000-0000-000000000004")!,
+        name: "Replace Selection",
+        icon: "arrow.uturn.down.square",
+        type: .pasteBack,
+        isEnabled: false,
+        isBuiltIn: true,
+        showInActionList: false
+    )
+
     /// All built-in destinations, seeded on first launch
-    static let all: [OutputDestination] = [email, notes, reminders]
+    static let all: [OutputDestination] = [email, notes, reminders, pasteBack]
 }

--- a/Cai/Cai/Models/CaiSettings.swift
+++ b/Cai/Cai/Models/CaiSettings.swift
@@ -385,7 +385,16 @@ class CaiSettings: ObservableObject {
 
         if let data = defaults.data(forKey: Keys.outputDestinations),
            let decoded = try? JSONDecoder().decode([OutputDestination].self, from: data) {
-            self.outputDestinations = decoded
+            // Seed any built-in destinations added after the user's first launch.
+            // Existing users loaded `decoded` from UserDefaults, so new entries in
+            // `BuiltInDestinations.all` won't appear otherwise.
+            let existingIds = Set(decoded.map(\.id))
+            let missingBuiltIns = BuiltInDestinations.all.filter { !existingIds.contains($0.id) }
+            if missingBuiltIns.isEmpty {
+                self.outputDestinations = decoded
+            } else {
+                self.outputDestinations = decoded + missingBuiltIns
+            }
         } else {
             self.outputDestinations = BuiltInDestinations.all
         }

--- a/Cai/Cai/Models/CaiShortcut.swift
+++ b/Cai/Cai/Models/CaiShortcut.swift
@@ -10,6 +10,10 @@ struct CaiShortcut: Codable, Identifiable, Equatable {
     var name: String
     var type: ShortcutType
     var value: String  // prompt text or URL template with %s
+    /// When true (prompt-type only), the LLM response is pasted straight over
+    /// the user's current selection in the source app, skipping the result
+    /// review UI. Defaults to false.
+    var autoReplaceSelection: Bool
 
     enum ShortcutType: String, Codable, CaseIterable {
         case prompt
@@ -41,10 +45,26 @@ struct CaiShortcut: Codable, Identifiable, Equatable {
         }
     }
 
-    init(id: UUID = UUID(), name: String, type: ShortcutType, value: String) {
+    init(id: UUID = UUID(), name: String, type: ShortcutType, value: String, autoReplaceSelection: Bool = false) {
         self.id = id
         self.name = name
         self.type = type
         self.value = value
+        self.autoReplaceSelection = autoReplaceSelection
+    }
+
+    // Custom decoder so previously-persisted shortcuts (without the flag) still
+    // decode, defaulting to false.
+    init(from decoder: Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        self.id = try c.decode(UUID.self, forKey: .id)
+        self.name = try c.decode(String.self, forKey: .name)
+        self.type = try c.decode(ShortcutType.self, forKey: .type)
+        self.value = try c.decode(String.self, forKey: .value)
+        self.autoReplaceSelection = try c.decodeIfPresent(Bool.self, forKey: .autoReplaceSelection) ?? false
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case id, name, type, value, autoReplaceSelection
     }
 }

--- a/Cai/Cai/Models/OutputDestination.swift
+++ b/Cai/Cai/Models/OutputDestination.swift
@@ -48,6 +48,10 @@ enum DestinationType: Equatable {
     case webhook(WebhookConfig)
     case deeplink(template: String)
     case shell(command: String)
+    /// Pastes the result over the current selection in the source app
+    /// (the app that was frontmost when Cai was invoked). No template:
+    /// the LLM result text is pasted verbatim via simulated Cmd+V.
+    case pasteBack
 
     var label: String {
         switch self {
@@ -55,6 +59,7 @@ enum DestinationType: Equatable {
         case .webhook: return "Webhook"
         case .deeplink: return "Deeplink"
         case .shell: return "Shell Command"
+        case .pasteBack: return "Replace Selection"
         }
     }
 
@@ -65,6 +70,7 @@ enum DestinationType: Equatable {
         case .webhook: return "webhook"
         case .deeplink: return "deeplink"
         case .shell: return "shell"
+        case .pasteBack: return "pasteBack"
         }
     }
 }
@@ -73,7 +79,7 @@ enum DestinationType: Equatable {
 
 extension DestinationType: Codable {
     private enum CodingKeys: String, CodingKey {
-        case applescript, webhook, deeplink, shell
+        case applescript, webhook, deeplink, shell, pasteBack
         case urlScheme // legacy
     }
 
@@ -100,6 +106,8 @@ extension DestinationType: Codable {
         } else if container.contains(.shell) {
             let nested = try container.nestedContainer(keyedBy: NestedKeys.self, forKey: .shell)
             self = .shell(command: try nested.decode(String.self, forKey: .command))
+        } else if container.contains(.pasteBack) {
+            self = .pasteBack
         } else {
             throw DecodingError.dataCorrupted(.init(
                 codingPath: decoder.codingPath,
@@ -123,6 +131,9 @@ extension DestinationType: Codable {
         case .shell(let command):
             var nested = container.nestedContainer(keyedBy: NestedKeys.self, forKey: .shell)
             try nested.encode(command, forKey: .command)
+        case .pasteBack:
+            // No associated value: presence of the key is the signal.
+            try container.encode(true, forKey: .pasteBack)
         }
     }
 }

--- a/Cai/Cai/Models/OutputDestination.swift
+++ b/Cai/Cai/Models/OutputDestination.swift
@@ -191,6 +191,7 @@ enum OutputDestinationError: LocalizedError {
     case shellFailed(Int, String)
     case notConfigured(String)
     case timeout
+    case pasteBackFailed
 
     var errorDescription: String? {
         switch self {
@@ -206,6 +207,8 @@ enum OutputDestinationError: LocalizedError {
             return "Missing setup: \(field)"
         case .timeout:
             return "Operation timed out"
+        case .pasteBackFailed:
+            return "Could not paste the response. Check Accessibility permission."
         }
     }
 }

--- a/Cai/Cai/Services/ClipboardService.swift
+++ b/Cai/Cai/Services/ClipboardService.swift
@@ -89,23 +89,23 @@ class ClipboardService {
 
     /// Pastes `text` into the app identified by `bundleId` by simulating Cmd+V.
     ///
-    /// Flow: re-activate the source app (Cai has stolen focus by now), briefly wait
-    /// for the activation to take effect, overwrite the general pasteboard with
-    /// `text`, post Cmd+V via CGEvent (same private-source + flag-override trick as
-    /// copy), then restore the prior pasteboard contents after a short delay so the
-    /// user's clipboard isn't left holding the AI result.
+    /// Flow: snapshot the whole pasteboard (every item, every type) so images,
+    /// file URLs, and rich text survive the round trip. Re-activate the source
+    /// app (Cai has stolen focus by now), briefly wait for the activation to
+    /// take effect, overwrite the pasteboard with `text`, post Cmd+V via CGEvent
+    /// (same private-source + flag-override trick as copy), then restore the
+    /// snapshot after a short delay.
     ///
-    /// Requirements mirror `copySelectedText`: Accessibility permission, App Sandbox
-    /// disabled. Keycode for V is 9 (kVK_ANSI_V).
-    func pasteResult(_ text: String, toBundleId bundleId: String?, completion: @escaping () -> Void) {
+    /// `completion(true)` is called only if the paste was actually posted.
+    /// Any early exit (CGEventSource creation fail, CGEvent build fail) restores
+    /// the snapshot first and calls `completion(false)` so callers can show an
+    /// accurate "something broke" toast instead of a misleading success.
+    ///
+    /// Requirements mirror `copySelectedText`: Accessibility permission, App
+    /// Sandbox disabled. Keycode for V is 9 (kVK_ANSI_V).
+    func pasteResult(_ text: String, toBundleId bundleId: String?, completion: @escaping (Bool) -> Void) {
         let pasteboard = NSPasteboard.general
-
-        // Snapshot the current pasteboard string so we can restore it afterwards.
-        // Only the primary string representation is preserved. Rich content (images,
-        // file URLs) is not, which is an accepted trade-off: pasteResult is only
-        // reached from an LLM text flow where the user's prior selection already
-        // lives on the pasteboard as a string.
-        let priorString = pasteboard.string(forType: .string)
+        let snapshot = PasteboardSnapshot(pasteboard)
 
         // Re-activate the source app if known. Without this, Cmd+V would be
         // delivered to Cai (frontmost after the panel became key).
@@ -124,7 +124,8 @@ class ClipboardService {
 
             guard let eventSource = CGEventSource(stateID: .privateState) else {
                 print("❌ Failed to create CGEventSource for paste")
-                completion()
+                snapshot.restore(to: pasteboard)
+                completion(false)
                 return
             }
 
@@ -133,7 +134,8 @@ class ClipboardService {
             guard let keyDown = CGEvent(keyboardEventSource: eventSource, virtualKey: keyCodeV, keyDown: true),
                   let keyUp = CGEvent(keyboardEventSource: eventSource, virtualKey: keyCodeV, keyDown: false) else {
                 print("❌ Failed to create CGEvent for paste")
-                completion()
+                snapshot.restore(to: pasteboard)
+                completion(false)
                 return
             }
 
@@ -145,16 +147,48 @@ class ClipboardService {
 
             print("⌨️ Posted Cmd+V via CGEvent to \(bundleId ?? "frontmost app")")
 
-            // Restore the prior pasteboard after a delay long enough for the target
-            // app to consume our text. 400ms is conservative: fast apps finish the
-            // paste in ~50ms, slow Electron apps can take ~200ms.
+            // Restore the snapshot after a delay long enough for the target
+            // app to consume our text. 400ms is conservative: fast apps finish
+            // the paste in ~50ms, slow Electron apps can take ~200ms.
             DispatchQueue.main.asyncAfter(deadline: .now() + 0.4) {
-                pasteboard.clearContents()
-                if let priorString = priorString {
-                    pasteboard.setString(priorString, forType: .string)
-                }
-                completion()
+                snapshot.restore(to: pasteboard)
+                completion(true)
             }
+        }
+    }
+
+    /// Snapshot of every NSPasteboardItem on the pasteboard at a moment in time.
+    /// Captures every declared type per item as raw Data, so images, file URLs,
+    /// RTF, plain text etc. all survive a clear + restore cycle. NSPasteboardItem
+    /// instances themselves are invalidated by `clearContents()`, so we can't
+    /// just hang on to the original objects: we have to extract the data eagerly
+    /// and rebuild fresh items on restore.
+    private struct PasteboardSnapshot {
+        private let items: [[NSPasteboard.PasteboardType: Data]]
+
+        init(_ pasteboard: NSPasteboard) {
+            self.items = pasteboard.pasteboardItems?.map { item in
+                var dict: [NSPasteboard.PasteboardType: Data] = [:]
+                for type in item.types {
+                    if let data = item.data(forType: type) {
+                        dict[type] = data
+                    }
+                }
+                return dict
+            } ?? []
+        }
+
+        func restore(to pasteboard: NSPasteboard) {
+            pasteboard.clearContents()
+            guard !items.isEmpty else { return }
+            let fresh = items.map { dict -> NSPasteboardItem in
+                let item = NSPasteboardItem()
+                for (type, data) in dict {
+                    item.setData(data, forType: type)
+                }
+                return item
+            }
+            pasteboard.writeObjects(fresh)
         }
     }
 

--- a/Cai/Cai/Services/ClipboardService.swift
+++ b/Cai/Cai/Services/ClipboardService.swift
@@ -87,6 +87,77 @@ class ClipboardService {
         }
     }
 
+    /// Pastes `text` into the app identified by `bundleId` by simulating Cmd+V.
+    ///
+    /// Flow: re-activate the source app (Cai has stolen focus by now), briefly wait
+    /// for the activation to take effect, overwrite the general pasteboard with
+    /// `text`, post Cmd+V via CGEvent (same private-source + flag-override trick as
+    /// copy), then restore the prior pasteboard contents after a short delay so the
+    /// user's clipboard isn't left holding the AI result.
+    ///
+    /// Requirements mirror `copySelectedText`: Accessibility permission, App Sandbox
+    /// disabled. Keycode for V is 9 (kVK_ANSI_V).
+    func pasteResult(_ text: String, toBundleId bundleId: String?, completion: @escaping () -> Void) {
+        let pasteboard = NSPasteboard.general
+
+        // Snapshot the current pasteboard string so we can restore it afterwards.
+        // Only the primary string representation is preserved. Rich content (images,
+        // file URLs) is not, which is an accepted trade-off: pasteResult is only
+        // reached from an LLM text flow where the user's prior selection already
+        // lives on the pasteboard as a string.
+        let priorString = pasteboard.string(forType: .string)
+
+        // Re-activate the source app if known. Without this, Cmd+V would be
+        // delivered to Cai (frontmost after the panel became key).
+        let reactivationDelay: TimeInterval
+        if let bundleId = bundleId,
+           let app = NSRunningApplication.runningApplications(withBundleIdentifier: bundleId).first {
+            app.activate(options: [])
+            reactivationDelay = 0.08  // Give the WindowServer a moment to swap focus
+        } else {
+            reactivationDelay = 0
+        }
+
+        DispatchQueue.main.asyncAfter(deadline: .now() + reactivationDelay) {
+            pasteboard.clearContents()
+            pasteboard.setString(text, forType: .string)
+
+            guard let eventSource = CGEventSource(stateID: .privateState) else {
+                print("❌ Failed to create CGEventSource for paste")
+                completion()
+                return
+            }
+
+            let keyCodeV: CGKeyCode = 9  // kVK_ANSI_V
+
+            guard let keyDown = CGEvent(keyboardEventSource: eventSource, virtualKey: keyCodeV, keyDown: true),
+                  let keyUp = CGEvent(keyboardEventSource: eventSource, virtualKey: keyCodeV, keyDown: false) else {
+                print("❌ Failed to create CGEvent for paste")
+                completion()
+                return
+            }
+
+            keyDown.flags = .maskCommand
+            keyUp.flags = .maskCommand
+
+            keyDown.post(tap: .cgAnnotatedSessionEventTap)
+            keyUp.post(tap: .cgAnnotatedSessionEventTap)
+
+            print("⌨️ Posted Cmd+V via CGEvent to \(bundleId ?? "frontmost app")")
+
+            // Restore the prior pasteboard after a delay long enough for the target
+            // app to consume our text. 400ms is conservative: fast apps finish the
+            // paste in ~50ms, slow Electron apps can take ~200ms.
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.4) {
+                pasteboard.clearContents()
+                if let priorString = priorString {
+                    pasteboard.setString(priorString, forType: .string)
+                }
+                completion()
+            }
+        }
+    }
+
     /// Reads text content from the system clipboard
     /// - Returns: Trimmed text content, or nil if clipboard is empty or doesn't contain text
     func readClipboard() -> String? {

--- a/Cai/Cai/Services/OutputDestinationService.swift
+++ b/Cai/Cai/Services/OutputDestinationService.swift
@@ -36,12 +36,15 @@ actor OutputDestinationService {
     // MARK: - Paste Back
 
     private func executePasteBack(text: String, sourceBundleId: String?) async throws {
-        await withCheckedContinuation { (continuation: CheckedContinuation<Void, Never>) in
+        let success = await withCheckedContinuation { (continuation: CheckedContinuation<Bool, Never>) in
             Task { @MainActor in
-                ClipboardService.shared.pasteResult(text, toBundleId: sourceBundleId) {
-                    continuation.resume()
+                ClipboardService.shared.pasteResult(text, toBundleId: sourceBundleId) { success in
+                    continuation.resume(returning: success)
                 }
             }
+        }
+        if !success {
+            throw OutputDestinationError.pasteBackFailed
         }
     }
 

--- a/Cai/Cai/Services/OutputDestinationService.swift
+++ b/Cai/Cai/Services/OutputDestinationService.swift
@@ -10,7 +10,10 @@ actor OutputDestinationService {
     // MARK: - Execute
 
     /// Sends text to the given destination, resolving all template placeholders.
-    func execute(_ destination: OutputDestination, with text: String) async throws {
+    ///
+    /// `sourceBundleId` is required for `.pasteBack`: it identifies the app to
+    /// re-activate before pasting. Other destination types ignore it.
+    func execute(_ destination: OutputDestination, with text: String, sourceBundleId: String? = nil) async throws {
         // Verify all setup fields are configured
         for field in destination.setupFields where field.value.isEmpty {
             throw OutputDestinationError.notConfigured(field.key)
@@ -25,6 +28,20 @@ actor OutputDestinationService {
             try await executeDeeplink(template, text: text, fields: destination.setupFields)
         case .shell(let command):
             try await executeShell(command, text: text, fields: destination.setupFields)
+        case .pasteBack:
+            try await executePasteBack(text: text, sourceBundleId: sourceBundleId)
+        }
+    }
+
+    // MARK: - Paste Back
+
+    private func executePasteBack(text: String, sourceBundleId: String?) async throws {
+        await withCheckedContinuation { (continuation: CheckedContinuation<Void, Never>) in
+            Task { @MainActor in
+                ClipboardService.shared.pasteResult(text, toBundleId: sourceBundleId) {
+                    continuation.resume()
+                }
+            }
         }
     }
 

--- a/Cai/Cai/Views/ActionListWindow.swift
+++ b/Cai/Cai/Views/ActionListWindow.swift
@@ -1090,10 +1090,13 @@ struct ActionListWindow: View {
                         let result = try await LLMService.shared.generateWithMessages(initialMessages, config: config)
                         let trimmed = result.trimmingCharacters(in: .whitespacesAndNewlines)
                         await MainActor.run {
-                            ClipboardService.shared.pasteResult(trimmed, toBundleId: bundleId) {
+                            ClipboardService.shared.pasteResult(trimmed, toBundleId: bundleId) { success in
+                                let message = success
+                                    ? "Replaced selection"
+                                    : "Could not paste. Check Accessibility permission."
                                 NotificationCenter.default.post(
                                     name: .caiShowToast, object: nil,
-                                    userInfo: ["message": "Replaced selection"]
+                                    userInfo: ["message": message]
                                 )
                             }
                         }
@@ -1589,8 +1592,15 @@ struct ActionListWindow: View {
     // MARK: - Output Destinations
 
     private func executeDestination(_ destination: OutputDestination, with text: String) {
-        // Always copy to clipboard first
-        SystemActions.copyToClipboard(text)
+        // Copy to clipboard as a fallback "you can paste this somewhere" side-effect.
+        // Skipped for .pasteBack because pasteResult snapshots the pasteboard first,
+        // and if we clobber it here that snapshot captures the AI text instead of
+        // whatever the user had on their clipboard, defeating the whole point.
+        if case .pasteBack = destination.type {
+            // handled entirely inside pasteResult
+        } else {
+            SystemActions.copyToClipboard(text)
+        }
 
         Task {
             do {

--- a/Cai/Cai/Views/ActionListWindow.swift
+++ b/Cai/Cai/Views/ActionListWindow.swift
@@ -140,7 +140,8 @@ struct ActionListWindow: View {
                     subtitle: subtitle,
                     icon: sc.type.icon,
                     shortcut: shortcut,
-                    type: actionType
+                    type: actionType,
+                    autoReplaceSelection: sc.type == .prompt && sc.autoReplaceSelection
                 ))
                 shortcut += 1
             }
@@ -1072,6 +1073,42 @@ struct ActionListWindow: View {
             let prompts = LLMService.prompts(for: llmAction, text: clipboardText, appContext: app)
             let initialMessages = buildInitialMessages(systemPrompt: prompts.system, userPrompt: prompts.user)
             let config = GenerationConfig.forAction(llmAction)
+
+            // Fast-path: user-configured shortcut marked "auto replace selection".
+            // Skip the result view; dismiss Cai, generate in the background, then
+            // paste the response over the source app's selection via Cmd+V.
+            if action.autoReplaceSelection {
+                let bundleId = self.sourceBundleId
+                let shortcutName = action.title
+                onDismiss()
+                NotificationCenter.default.post(
+                    name: .caiShowToast, object: nil,
+                    userInfo: ["message": "Generating: \(shortcutName)"]
+                )
+                Task {
+                    do {
+                        let result = try await LLMService.shared.generateWithMessages(initialMessages, config: config)
+                        let trimmed = result.trimmingCharacters(in: .whitespacesAndNewlines)
+                        await MainActor.run {
+                            ClipboardService.shared.pasteResult(trimmed, toBundleId: bundleId) {
+                                NotificationCenter.default.post(
+                                    name: .caiShowToast, object: nil,
+                                    userInfo: ["message": "Replaced selection"]
+                                )
+                            }
+                        }
+                    } catch {
+                        await MainActor.run {
+                            NotificationCenter.default.post(
+                                name: .caiShowToast, object: nil,
+                                userInfo: ["message": "Error: \(error.localizedDescription)"]
+                            )
+                        }
+                    }
+                }
+                return
+            }
+
             conversationHistory = initialMessages
             activeConfig = config
             isFollowUpEnabled = true
@@ -1557,7 +1594,7 @@ struct ActionListWindow: View {
 
         Task {
             do {
-                try await OutputDestinationService.shared.execute(destination, with: text)
+                try await OutputDestinationService.shared.execute(destination, with: text, sourceBundleId: sourceBundleId)
                 await MainActor.run {
                     // Dismiss first — orderOut removes the main window from the
                     // display hierarchy so the toast's NSHostingView doesn't conflict.

--- a/Cai/Cai/Views/DestinationsManagementView.swift
+++ b/Cai/Cai/Views/DestinationsManagementView.swift
@@ -567,6 +567,11 @@ struct DestinationsManagementView: View {
         case .shell(let command):
             formTypeTag = "shell"
             formShellCommand = command
+        case .pasteBack:
+            // pasteBack is built-in only and has no configurable fields, so the
+            // edit form is never reached via this case. Fall back to webhook defaults
+            // to avoid leaving form state uninitialized if an extension ever tries.
+            formTypeTag = "webhook"
         }
     }
 
@@ -680,6 +685,10 @@ struct DestinationsManagementView: View {
                 .map { "  \($0)" }.joined(separator: "\n")
             yaml += "\ntype: applescript"
             yaml += "\napplescript: |\n\(indented)"
+
+        case .pasteBack:
+            // pasteBack is built-in only; not shareable as an extension.
+            return
         }
 
         // Setup fields

--- a/Cai/Cai/Views/ShortcutsManagementView.swift
+++ b/Cai/Cai/Views/ShortcutsManagementView.swift
@@ -15,6 +15,7 @@ struct ShortcutsManagementView: View {
     @State private var formName: String = ""
     @State private var formType: CaiShortcut.ShortcutType = .prompt
     @State private var formValue: String = ""
+    @State private var formAutoReplace: Bool = false
 
     var body: some View {
         VStack(spacing: 0) {
@@ -189,6 +190,7 @@ struct ShortcutsManagementView: View {
                 formName = shortcut.name
                 formType = shortcut.type
                 formValue = shortcut.value
+                formAutoReplace = shortcut.autoReplaceSelection
                 editingShortcutId = shortcut.id
                 WindowController.passThrough = true
             }) {
@@ -309,6 +311,23 @@ struct ShortcutsManagementView: View {
                 }
             }
 
+            // Auto replace selection, prompt-type only
+            if formType == .prompt {
+                Toggle(isOn: $formAutoReplace) {
+                    VStack(alignment: .leading, spacing: 2) {
+                        Text("Auto replace selection")
+                            .font(.system(size: 11, weight: .medium))
+                            .foregroundColor(.caiTextPrimary)
+                        Text("Paste the response over your selection and skip the review screen.")
+                            .font(.system(size: 10))
+                            .foregroundColor(.caiTextSecondary.opacity(0.6))
+                            .fixedSize(horizontal: false, vertical: true)
+                    }
+                }
+                .toggleStyle(.switch)
+                .controlSize(.mini)
+            }
+
             // Save / Cancel buttons
             HStack(spacing: 8) {
                 Button("Cancel") {
@@ -358,8 +377,11 @@ struct ShortcutsManagementView: View {
         let trimmedValue = formValue.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !trimmedName.isEmpty, !trimmedValue.isEmpty else { return }
 
+        // Only the prompt type supports auto-replace; other types silently drop it.
+        let autoReplace = formType == .prompt && formAutoReplace
+
         if isNew {
-            let shortcut = CaiShortcut(name: trimmedName, type: formType, value: trimmedValue)
+            let shortcut = CaiShortcut(name: trimmedName, type: formType, value: trimmedValue, autoReplaceSelection: autoReplace)
             withAnimation(.easeInOut(duration: 0.15)) {
                 settings.shortcuts.append(shortcut)
             }
@@ -369,6 +391,7 @@ struct ShortcutsManagementView: View {
                 settings.shortcuts[index].name = trimmedName
                 settings.shortcuts[index].type = formType
                 settings.shortcuts[index].value = trimmedValue
+                settings.shortcuts[index].autoReplaceSelection = autoReplace
             }
         }
 
@@ -384,6 +407,7 @@ struct ShortcutsManagementView: View {
         formName = ""
         formType = .prompt
         formValue = ""
+        formAutoReplace = false
     }
 
     // MARK: - Share as Extension


### PR DESCRIPTION
Two new ways to route LLM output back into the source app.

The first is a new built-in Replace Selection destination, off by default. It shows up in the result view chips next to Email, Notes, and Reminders. Clicking it pastes the response over whatever was selected when Cai was invoked.

The second is a new Auto replace toggle on prompt-type shortcuts. Picking such a shortcut from the action list dismisses Cai, runs the LLM in the background, and pastes the result inline without ever showing the result view.

Both paths share a new ClipboardService.pasteResult method. It uses the same CGEvent approach as copySelectedText: private source, explicit maskCommand flag to override any held modifier, posted at cgAnnotatedSessionEventTap. It re-activates the source app via its bundle id first (since Cai's panel stole focus), then restores the prior clipboard contents after 400ms so the user's clipboard isn't left holding AI text.

CaiShortcut gets an autoReplaceSelection field with a backward-compat decoder that defaults to false for shortcuts persisted before this change. CaiSettings.init now seeds any new built-in destinations on launch so existing users get the Replace Selection entry without needing to reset their output destinations.