### PR TITLE
Add OpenRouter provider and make the main panel resizable

### DIFF
--- a/Cai/Cai/Models/CaiSettings.swift
+++ b/Cai/Cai/Models/CaiSettings.swift
@@ -34,7 +34,8 @@ class CaiSettings: ObservableObject {
         static let installedExtensions = "cai_installedExtensions"
         static let appearance = "cai_appearance"
         static let anthropicModelName = "cai_anthropicModelName"
-        // apiKey moved to Keychain — see KeychainHelper
+        static let openRouterModelName = "cai_openRouterModelName"
+        // apiKey moved to Keychain, see KeychainHelper
     }
 
     // MARK: - Model Provider
@@ -45,6 +46,7 @@ class CaiSettings: ObservableObject {
         case lmstudio = "LM Studio"
         case ollama = "Ollama"
         case anthropic = "Anthropic"
+        case openrouter = "OpenRouter"
         case custom = "Custom"
 
         var id: String { rawValue }
@@ -53,10 +55,11 @@ class CaiSettings: ObservableObject {
         var defaultURL: String {
             switch self {
             case .builtIn: return "http://127.0.0.1:8690"
-            case .apple: return ""  // No HTTP endpoint — uses FoundationModels framework
+            case .apple: return ""  // No HTTP endpoint, uses FoundationModels framework.
             case .lmstudio: return "http://127.0.0.1:1234"
             case .ollama: return "http://127.0.0.1:11434"
             case .anthropic: return "https://api.anthropic.com"
+            case .openrouter: return "https://openrouter.ai/api"
             case .custom: return ""
             }
         }
@@ -174,19 +177,31 @@ class CaiSettings: ObservableObject {
             return modelProvider.defaultURL
         case .anthropic:
             return "https://api.anthropic.com"
+        case .openrouter:
+            return "https://openrouter.ai/api"
         case .custom:
             return customModelURL
         }
     }
 
     /// Anthropic model name (e.g. "claude-sonnet-4-6").
-    /// Hardcoded picker in Settings — Anthropic has no /v1/models endpoint.
+    /// Hardcoded picker in Settings, Anthropic has no /v1/models endpoint.
     @Published var anthropicModelName: String {
         didSet { defaults.set(anthropicModelName, forKey: Keys.anthropicModelName) }
     }
 
     /// Default Anthropic model ID. Users can override in Settings.
     static let defaultAnthropicModel = "claude-sonnet-4-6"
+
+    /// OpenRouter model slug (e.g. "openai/gpt-4o-mini", "anthropic/claude-3.5-sonnet").
+    /// Routed through OpenRouter's OpenAI-compatible chat completions endpoint.
+    /// Users pick the slug from the model list at openrouter.ai/models.
+    @Published var openRouterModelName: String {
+        didSet { defaults.set(openRouterModelName, forKey: Keys.openRouterModelName) }
+    }
+
+    /// Default OpenRouter model slug. Cheap and fast, a reasonable starting point.
+    static let defaultOpenRouterModel = "openai/gpt-4o-mini"
 
     /// HuggingFace model ID for the built-in MLX model (e.g., "mlx-community/Ministral-3-3B-Instruct-2512-4bit")
     @Published var builtInModelId: String {
@@ -229,13 +244,26 @@ class CaiSettings: ObservableObject {
     }
 
     /// Dedicated API key for Anthropic (Claude API). Separate from `apiKey` to prevent
-    /// cross-provider key leakage — Anthropic uses `x-api-key` header, not Bearer.
+    /// cross-provider key leakage, Anthropic uses `x-api-key` header, not Bearer.
     @Published var anthropicApiKey: String {
         didSet {
             if anthropicApiKey.isEmpty {
                 KeychainHelper.delete(forKey: "cai_anthropicApiKey")
             } else {
                 KeychainHelper.set(anthropicApiKey, forKey: "cai_anthropicApiKey")
+            }
+        }
+    }
+
+    /// Dedicated API key for OpenRouter. Kept separate from the shared `apiKey`
+    /// so users can configure OpenRouter alongside a local LM Studio / Ollama
+    /// server without the keys getting crossed.
+    @Published var openRouterApiKey: String {
+        didSet {
+            if openRouterApiKey.isEmpty {
+                KeychainHelper.delete(forKey: "cai_openRouterApiKey")
+            } else {
+                KeychainHelper.set(openRouterApiKey, forKey: "cai_openRouterApiKey")
             }
         }
     }
@@ -354,6 +382,9 @@ class CaiSettings: ObservableObject {
         self.anthropicModelName = defaults.string(forKey: Keys.anthropicModelName)
             ?? Self.defaultAnthropicModel
 
+        self.openRouterModelName = defaults.string(forKey: Keys.openRouterModelName)
+            ?? Self.defaultOpenRouterModel
+
         // API key: read from Keychain, migrate from UserDefaults if needed
         if let keychainKey = KeychainHelper.get(forKey: "cai_apiKey") {
             self.apiKey = keychainKey
@@ -371,6 +402,13 @@ class CaiSettings: ObservableObject {
             self.anthropicApiKey = anthropicKey
         } else {
             self.anthropicApiKey = ""
+        }
+
+        // OpenRouter API key: separate Keychain entry
+        if let openRouterKey = KeychainHelper.get(forKey: "cai_openRouterApiKey") {
+            self.openRouterApiKey = openRouterKey
+        } else {
+            self.openRouterApiKey = ""
         }
 
         let mapsRaw = defaults.string(forKey: Keys.mapsProvider) ?? MapsProvider.apple.rawValue

--- a/Cai/Cai/Services/LLMService.swift
+++ b/Cai/Cai/Services/LLMService.swift
@@ -78,8 +78,21 @@ actor LLMService {
     private var cachedModelName: String?
 
     /// Applies the API key as a Bearer token if one is configured.
+    /// Picks the right key per provider so OpenRouter's key doesn't clobber
+    /// a local LM Studio / Ollama setup (and vice versa).
     private func applyAuth(to request: inout URLRequest) async {
-        let key = await MainActor.run { CaiSettings.shared.apiKey }
+        let provider = await MainActor.run { CaiSettings.shared.modelProvider }
+        let key: String
+        switch provider {
+        case .openrouter:
+            key = await MainActor.run { CaiSettings.shared.openRouterApiKey }
+            // OpenRouter uses these for traffic attribution on their model leaderboards.
+            // Harmless to send, helps us show up as a known client.
+            request.setValue("https://getcai.app", forHTTPHeaderField: "HTTP-Referer")
+            request.setValue("Cai", forHTTPHeaderField: "X-Title")
+        default:
+            key = await MainActor.run { CaiSettings.shared.apiKey }
+        }
         if !key.isEmpty {
             request.setValue("Bearer \(key)", forHTTPHeaderField: "Authorization")
         }
@@ -112,7 +125,7 @@ actor LLMService {
             return checkAppleFMStatus()
         }
 
-        // Anthropic — check API key is configured. No validation call — Anthropic's
+        // Anthropic, check API key is configured. No validation call, Anthropic's
         // API has quirks with lightweight probe requests (intermittent temperature/top_p
         // rejection on alias model IDs). Real errors surface on first action instead.
         if provider == .anthropic {
@@ -122,6 +135,19 @@ actor LLMService {
             }
             let model = await MainActor.run { CaiSettings.shared.anthropicModelName }
             return Status(available: true, modelName: model, error: nil)
+        }
+
+        // OpenRouter, check API key is configured. Don't probe /v1/models, the
+        // list is hundreds of entries long and the user has already picked a
+        // specific slug via openRouterModelName. Real errors surface on first action.
+        if provider == .openrouter {
+            let key = await MainActor.run { CaiSettings.shared.openRouterApiKey }
+            if key.isEmpty {
+                return Status(available: false, modelName: nil, error: "No API key")
+            }
+            let model = await MainActor.run { CaiSettings.shared.openRouterModelName }
+            let resolved = model.isEmpty ? CaiSettings.defaultOpenRouterModel : model
+            return Status(available: true, modelName: resolved, error: nil)
         }
 
         let baseURL = await MainActor.run { CaiSettings.shared.modelURL }
@@ -172,6 +198,13 @@ actor LLMService {
             let model = await MainActor.run { CaiSettings.shared.anthropicModelName }
             return [model]
         }
+        // OpenRouter: only query if the user has entered a key. Their /v1/models
+        // endpoint is actually open to unauth'd callers, but we want the list to
+        // act as a key validity signal, so no key means no list.
+        if provider == .openrouter {
+            let key = await MainActor.run { CaiSettings.shared.openRouterApiKey }
+            if key.isEmpty { return [] }
+        }
 
         let baseURL = await MainActor.run { CaiSettings.shared.modelURL }
         guard !baseURL.isEmpty,
@@ -191,7 +224,13 @@ actor LLMService {
             }
             if let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
                let models = json["data"] as? [[String: Any]] {
-                return models.compactMap { $0["id"] as? String }
+                let ids = models.compactMap { $0["id"] as? String }
+                // OpenRouter returns models in popularity / recency order, which
+                // isn't scannable when there are 400+ of them. Sort for that case.
+                if provider == .openrouter {
+                    return ids.sorted { $0.localizedCaseInsensitiveCompare($1) == .orderedAscending }
+                }
+                return ids
             }
         } catch {}
         return []
@@ -406,16 +445,23 @@ actor LLMService {
             throw LLMError.invalidURL
         }
 
-        // Use user-specified model name if set, otherwise auto-detect
-        let userModel = await MainActor.run { CaiSettings.shared.modelName }
+        // Use user-specified model name if set, otherwise auto-detect.
+        // OpenRouter has its own dedicated slug field since auto-detect against
+        // their /v1/models (hundreds of entries) would pick a random first model.
         let modelToUse: String
-        if !userModel.isEmpty {
-            modelToUse = userModel
+        if provider == .openrouter {
+            let slug = await MainActor.run { CaiSettings.shared.openRouterModelName }
+            modelToUse = slug.isEmpty ? CaiSettings.defaultOpenRouterModel : slug
         } else {
-            if cachedModelName == nil {
-                _ = await checkStatus()
+            let userModel = await MainActor.run { CaiSettings.shared.modelName }
+            if !userModel.isEmpty {
+                modelToUse = userModel
+            } else {
+                if cachedModelName == nil {
+                    _ = await checkStatus()
+                }
+                modelToUse = cachedModelName ?? ""
             }
-            modelToUse = cachedModelName ?? ""
         }
 
         let body = ChatRequest(

--- a/Cai/Cai/Services/WindowController.swift
+++ b/Cai/Cai/Services/WindowController.swift
@@ -80,7 +80,7 @@ class WindowController: NSObject, ObservableObject {
         }
     }
 
-    /// Default / minimum window height, always shows space for 9 rows (Spotlight-style).
+    /// Default / minimum window height. Sized to show `maxVisibleRows` rows (Spotlight-style).
     /// The window is vertically resizable: users can drag the bottom edge to grow it,
     /// useful for the Settings screens and long result bodies. Width stays pinned.
     private static var fixedWindowHeight: CGFloat {

--- a/Cai/Cai/Services/WindowController.swift
+++ b/Cai/Cai/Services/WindowController.swift
@@ -80,10 +80,25 @@ class WindowController: NSObject, ObservableObject {
         }
     }
 
-    /// Fixed window height — always shows space for 9 rows (Spotlight-style).
+    /// Default / minimum window height, always shows space for 9 rows (Spotlight-style).
+    /// The window is vertically resizable: users can drag the bottom edge to grow it,
+    /// useful for the Settings screens and long result bodies. Width stays pinned.
     private static var fixedWindowHeight: CGFloat {
         let contentHeight = maxVisibleRows * rowHeight + listVerticalPadding
         return headerHeight + dividerHeight + contentHeight + dividerHeight + footerHeight
+    }
+
+    private static let heightKey = "cai_windowHeight"
+
+    private static func saveWindowHeight(_ height: CGFloat) {
+        UserDefaults.standard.set(Double(height), forKey: heightKey)
+    }
+
+    private static func loadWindowHeight() -> CGFloat? {
+        let defaults = UserDefaults.standard
+        guard defaults.object(forKey: heightKey) != nil else { return nil }
+        let height = CGFloat(defaults.double(forKey: heightKey))
+        return height >= fixedWindowHeight ? height : nil
     }
 
     /// Shows the action window in settings mode (triggered by menu bar left-click).
@@ -175,7 +190,7 @@ class WindowController: NSObject, ObservableObject {
         // Reset selection state
         selectionState = SelectionState()
 
-        let windowHeight = Self.fixedWindowHeight
+        let windowHeight = Self.loadWindowHeight() ?? Self.fixedWindowHeight
 
         // Create dismiss/execute closures
         let dismissAction: () -> Void = { [weak self] in
@@ -203,18 +218,21 @@ class WindowController: NSObject, ObservableObject {
         // to avoid double-handling).
         let hostingView = KeyEventHostingView(
             rootView: actionList
-                .frame(width: Self.windowWidth, height: windowHeight)
+                .frame(width: Self.windowWidth)
         )
         hostingView.frame = NSRect(x: 0, y: 0, width: Self.windowWidth, height: windowHeight)
+        hostingView.autoresizingMask = [.width, .height]  // follow panel when user drags to resize
         hostingView.wantsLayer = true
         hostingView.layer?.cornerRadius = Self.cornerRadius
         hostingView.layer?.cornerCurve = .continuous
         hostingView.layer?.masksToBounds = true
 
-        // Create borderless CaiPanel (custom subclass that returns YES from canBecomeKey)
+        // Create borderless resizable CaiPanel (custom subclass returns YES from canBecomeKey).
+        // `.resizable` lets the user drag the bottom edge to grow the window; min/max
+        // size pin the width so only vertical resize is possible.
         let panel = CaiPanel(
             contentRect: NSRect(x: 0, y: 0, width: Self.windowWidth, height: windowHeight),
-            styleMask: [.borderless],
+            styleMask: [.borderless, .resizable],
             backing: .buffered,
             defer: false
         )
@@ -224,6 +242,8 @@ class WindowController: NSObject, ObservableObject {
         panel.level = .floating
         panel.isMovableByWindowBackground = true  // Drag to reposition
         panel.contentView = hostingView
+        panel.minSize = NSSize(width: Self.windowWidth, height: Self.fixedWindowHeight)
+        panel.maxSize = NSSize(width: Self.windowWidth, height: .greatestFiniteMagnitude)
 
         // Allow the panel to become key so we receive keyboard events
         panel.isFloatingPanel = true
@@ -259,9 +279,10 @@ class WindowController: NSObject, ObservableObject {
     }
 
     func hideWindow() {
-        // Save window position before dismissing
-        if let origin = window?.frame.origin {
-            Self.saveWindowPosition(origin)
+        // Save window position and resized height before dismissing
+        if let frame = window?.frame {
+            Self.saveWindowPosition(frame.origin)
+            Self.saveWindowHeight(frame.height)
         }
         removeEventMonitors()
 

--- a/Cai/Cai/Views/SettingsView.swift
+++ b/Cai/Cai/Views/SettingsView.swift
@@ -19,6 +19,11 @@ struct SettingsView: View {
     @State private var availableModels: [String] = []
     /// Debounce task for LLM status checks (prevents API call storms during typing)
     @State private var statusCheckTask: Task<Void, Never>?
+    /// Debounce task for model list fetches (prevents API call storms during key paste/typing)
+    @State private var modelFetchTask: Task<Void, Never>?
+    /// Set to true when the last model fetch completed with an empty list while a key was present.
+    /// Used to tell the user "unable to load" vs "haven't tried yet".
+    @State private var modelListFetchFailed: Bool = false
 
     private var appVersion: String {
         Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "1.0"
@@ -98,38 +103,45 @@ struct SettingsView: View {
                                         .font(.system(size: 10))
                                         .foregroundColor(.caiTextSecondary.opacity(0.6))
 
-                                    // Model picker: populated from OpenRouter's /v1/models.
-                                    // Falls back to the typed slug if the fetch hasn't happened yet
-                                    // (offline / key not entered) so the user isn't locked out.
-                                    HStack(spacing: 8) {
-                                        Picker("", selection: $settings.openRouterModelName) {
-                                            if !availableModels.contains(settings.openRouterModelName) {
-                                                Text(settings.openRouterModelName.isEmpty
-                                                     ? CaiSettings.defaultOpenRouterModel
-                                                     : settings.openRouterModelName)
-                                                    .tag(settings.openRouterModelName)
-                                            }
-                                            ForEach(availableModels, id: \.self) { model in
-                                                Text(model).tag(model)
-                                            }
-                                        }
-                                        .labelsHidden()
-                                        .pickerStyle(.menu)
-                                        .accessibilityLabel("OpenRouter model")
-                                        .disabled(availableModels.isEmpty)
+                                    // Model selection: the text field is always editable so users can
+                                    // paste a slug manually (offline, fetch failed, or slug not yet in the list).
+                                    // When OpenRouter's /v1/models has been fetched, a picker is shown too
+                                    // for quick browsing.
+                                    VStack(alignment: .leading, spacing: 8) {
+                                        TextField("openrouter/model-slug", text: $settings.openRouterModelName)
+                                            .textFieldStyle(.roundedBorder)
+                                            .font(.system(size: 12, design: .monospaced))
+                                            .accessibilityLabel("OpenRouter model slug")
 
-                                        Button(action: { fetchAvailableModels() }) {
-                                            Image(systemName: "arrow.clockwise")
-                                                .font(.system(size: 10, weight: .medium))
-                                                .foregroundColor(.caiTextSecondary)
+                                        HStack(spacing: 8) {
+                                            if !availableModels.isEmpty {
+                                                Picker("", selection: $settings.openRouterModelName) {
+                                                    if !availableModels.contains(settings.openRouterModelName) {
+                                                        Text(settings.openRouterModelName.isEmpty
+                                                             ? CaiSettings.defaultOpenRouterModel
+                                                             : settings.openRouterModelName)
+                                                            .tag(settings.openRouterModelName)
+                                                    }
+                                                    ForEach(availableModels, id: \.self) { model in
+                                                        Text(model).tag(model)
+                                                    }
+                                                }
+                                                .labelsHidden()
+                                                .pickerStyle(.menu)
+                                                .accessibilityLabel("OpenRouter model")
+                                            }
+
+                                            Button(action: { fetchAvailableModels(debounce: false) }) {
+                                                Image(systemName: "arrow.clockwise")
+                                                    .font(.system(size: 10, weight: .medium))
+                                                    .foregroundColor(.caiTextSecondary)
+                                            }
+                                            .buttonStyle(.plain)
+                                            .help("Refresh model list")
                                         }
-                                        .buttonStyle(.plain)
-                                        .help("Refresh model list")
                                     }
 
-                                    Text(availableModels.isEmpty
-                                         ? "Enter your API key to load the model list"
-                                         : "\(availableModels.count) models available")
+                                    Text(openRouterModelListHelperText)
                                         .font(.system(size: 10))
                                         .foregroundColor(.caiTextSecondary.opacity(0.6))
                                 } else {
@@ -194,7 +206,7 @@ struct SettingsView: View {
                             .onChange(of: settings.openRouterModelName) { forceCheckLLMStatus() }
                             .onChange(of: settings.openRouterApiKey) {
                                 forceCheckLLMStatus()
-                                fetchAvailableModels()
+                                fetchAvailableModels(debounce: true)
                             }
                             .onChange(of: settings.apiKey) { forceCheckLLMStatus() }
                             .onChange(of: settings.customModelURL) { forceCheckLLMStatus(); fetchAvailableModels() }
@@ -846,13 +858,42 @@ struct SettingsView: View {
         }
     }
 
-    private func fetchAvailableModels() {
-        Task {
+    /// Fetches the active provider's model list. Pass `debounce: true` when this is triggered
+    /// by a fast-changing input (like the api key field) so we don't hit the provider on every
+    /// keystroke/paste chunk. Any in-flight fetch is cancelled when a new one starts.
+    private func fetchAvailableModels(debounce: Bool = false) {
+        modelFetchTask?.cancel()
+        modelFetchTask = Task {
+            if debounce {
+                try? await Task.sleep(for: .milliseconds(800))
+                guard !Task.isCancelled else { return }
+            }
             let models = await LLMService.shared.availableModels()
+            guard !Task.isCancelled else { return }
             await MainActor.run {
                 availableModels = models
+                // For providers that use a key (openrouter), empty list after a fetch attempt
+                // with a key present means the call failed (network, 401, 429, etc.).
+                modelListFetchFailed = models.isEmpty && !settings.openRouterApiKey.isEmpty
+                    && settings.modelProvider == .openrouter
             }
         }
+    }
+
+    /// Helper text under the OpenRouter model selector. Distinguishes "haven't entered a key yet"
+    /// from "key present but fetch returned nothing" so users aren't misled into thinking the key
+    /// step is still missing.
+    private var openRouterModelListHelperText: String {
+        if !availableModels.isEmpty {
+            return "\(availableModels.count) models available"
+        }
+        if settings.openRouterApiKey.isEmpty {
+            return "Enter a model slug above, or add your API key to load the model list"
+        }
+        if modelListFetchFailed {
+            return "Unable to load model list. Try refreshing."
+        }
+        return "Loading model list…"
     }
 
     // MARK: - Permission Indicator

--- a/Cai/Cai/Views/SettingsView.swift
+++ b/Cai/Cai/Views/SettingsView.swift
@@ -76,7 +76,7 @@ struct SettingsView: View {
                                         .font(.system(size: 12, design: .monospaced))
                                         .accessibilityLabel("Claude model name")
 
-                                    Text("Model ID \u{2014} e.g. claude-sonnet-4-6, claude-haiku-4-5, claude-opus-4-6")
+                                    Text("Model ID, e.g. claude-sonnet-4-6, claude-haiku-4-5, claude-opus-4-6")
                                         .font(.system(size: 10))
                                         .foregroundColor(.caiTextSecondary.opacity(0.6))
 
@@ -86,6 +86,50 @@ struct SettingsView: View {
                                         .accessibilityLabel("Anthropic API key")
 
                                     Text("API key from [console.anthropic.com](https://console.anthropic.com/)")
+                                        .font(.system(size: 10))
+                                        .foregroundColor(.caiTextSecondary.opacity(0.6))
+                                } else if settings.modelProvider == .openrouter {
+                                    SecureField("sk-or-v1-...", text: $settings.openRouterApiKey)
+                                        .textFieldStyle(.roundedBorder)
+                                        .font(.system(size: 12, design: .monospaced))
+                                        .accessibilityLabel("OpenRouter API key")
+
+                                    Text("API key from [openrouter.ai/keys](https://openrouter.ai/keys)")
+                                        .font(.system(size: 10))
+                                        .foregroundColor(.caiTextSecondary.opacity(0.6))
+
+                                    // Model picker: populated from OpenRouter's /v1/models.
+                                    // Falls back to the typed slug if the fetch hasn't happened yet
+                                    // (offline / key not entered) so the user isn't locked out.
+                                    HStack(spacing: 8) {
+                                        Picker("", selection: $settings.openRouterModelName) {
+                                            if !availableModels.contains(settings.openRouterModelName) {
+                                                Text(settings.openRouterModelName.isEmpty
+                                                     ? CaiSettings.defaultOpenRouterModel
+                                                     : settings.openRouterModelName)
+                                                    .tag(settings.openRouterModelName)
+                                            }
+                                            ForEach(availableModels, id: \.self) { model in
+                                                Text(model).tag(model)
+                                            }
+                                        }
+                                        .labelsHidden()
+                                        .pickerStyle(.menu)
+                                        .accessibilityLabel("OpenRouter model")
+                                        .disabled(availableModels.isEmpty)
+
+                                        Button(action: { fetchAvailableModels() }) {
+                                            Image(systemName: "arrow.clockwise")
+                                                .font(.system(size: 10, weight: .medium))
+                                                .foregroundColor(.caiTextSecondary)
+                                        }
+                                        .buttonStyle(.plain)
+                                        .help("Refresh model list")
+                                    }
+
+                                    Text(availableModels.isEmpty
+                                         ? "Enter your API key to load the model list"
+                                         : "\(availableModels.count) models available")
                                         .font(.system(size: 10))
                                         .foregroundColor(.caiTextSecondary.opacity(0.6))
                                 } else {
@@ -147,6 +191,11 @@ struct SettingsView: View {
                             }
                             .onChange(of: settings.anthropicModelName) { forceCheckLLMStatus() }
                             .onChange(of: settings.anthropicApiKey) { forceCheckLLMStatus() }
+                            .onChange(of: settings.openRouterModelName) { forceCheckLLMStatus() }
+                            .onChange(of: settings.openRouterApiKey) {
+                                forceCheckLLMStatus()
+                                fetchAvailableModels()
+                            }
                             .onChange(of: settings.apiKey) { forceCheckLLMStatus() }
                             .onChange(of: settings.customModelURL) { forceCheckLLMStatus(); fetchAvailableModels() }
                             .onChange(of: settings.modelName) { forceCheckLLMStatus() }


### PR DESCRIPTION
Two independent changes on one branch. Happy to split if reviewers prefer.

Adds OpenRouter as a model provider. Routed through the existing OpenAI-compatible chat completions path with dedicated openRouterApiKey (Keychain) and openRouterModelName (UserDefaults) so it doesn't clash with the shared apiKey that lmstudio / ollama / custom already share. The recommended HTTP-Referer and X-Title headers get attached when the provider is active.

Settings shows the api key field first. The model picker stays empty until a key is entered, then populates from /v1/models sorted A to Z. With 400+ models in their catalog the native popularity/recency order is hard to scan, so sorting felt worth the extra line.

Also makes the main floating panel vertically resizable. Users drag the bottom edge to grow the window, which matters for the settings screens and longer llm responses. Width stays pinned via minSize / maxSize so horizontal resize is blocked. The height persists across launches alongside the existing saved position.