### PR TITLE
feat: pin custom actions above built-ins

### DIFF
--- a/Cai/Cai/Models/CaiShortcut.swift
+++ b/Cai/Cai/Models/CaiShortcut.swift
@@ -14,6 +14,9 @@ struct CaiShortcut: Codable, Identifiable, Equatable {
     /// the user's current selection in the source app, skipping the result
     /// review UI. Defaults to false.
     var autoReplaceSelection: Bool
+    /// When true, this shortcut appears at the top of the default action list
+    /// (above built-ins) and consumes the first ⌘ numbers.
+    var pinned: Bool
 
     enum ShortcutType: String, Codable, CaseIterable {
         case prompt
@@ -45,16 +48,17 @@ struct CaiShortcut: Codable, Identifiable, Equatable {
         }
     }
 
-    init(id: UUID = UUID(), name: String, type: ShortcutType, value: String, autoReplaceSelection: Bool = false) {
+    init(id: UUID = UUID(), name: String, type: ShortcutType, value: String, autoReplaceSelection: Bool = false, pinned: Bool = false) {
         self.id = id
         self.name = name
         self.type = type
         self.value = value
         self.autoReplaceSelection = autoReplaceSelection
+        self.pinned = pinned
     }
 
-    // Custom decoder so previously-persisted shortcuts (without the flag) still
-    // decode, defaulting to false.
+    // Custom decoder so previously-persisted shortcuts (without newer flags)
+    // still decode, defaulting them to false.
     init(from decoder: Decoder) throws {
         let c = try decoder.container(keyedBy: CodingKeys.self)
         self.id = try c.decode(UUID.self, forKey: .id)
@@ -62,9 +66,10 @@ struct CaiShortcut: Codable, Identifiable, Equatable {
         self.type = try c.decode(ShortcutType.self, forKey: .type)
         self.value = try c.decode(String.self, forKey: .value)
         self.autoReplaceSelection = try c.decodeIfPresent(Bool.self, forKey: .autoReplaceSelection) ?? false
+        self.pinned = try c.decodeIfPresent(Bool.self, forKey: .pinned) ?? false
     }
 
     private enum CodingKeys: String, CodingKey {
-        case id, name, type, value, autoReplaceSelection
+        case id, name, type, value, autoReplaceSelection, pinned
     }
 }

--- a/Cai/Cai/Services/ActionGenerator.swift
+++ b/Cai/Cai/Services/ActionGenerator.swift
@@ -19,7 +19,13 @@ struct ActionGenerator {
         var items: [ActionItem] = []
         var shortcut = 1
 
-        // Ask AI (⌘1) — always first, for ALL content types
+        // Pinned custom shortcuts come first, ahead of Ask AI and all built-ins.
+        for sc in settings.shortcuts where sc.pinned {
+            items.append(actionItem(from: sc, clipboardText: text, shortcut: shortcut))
+            shortcut += 1
+        }
+
+        // Ask AI — first built-in.
         items.append(ActionItem(
             id: "custom_prompt",
             title: "Ask AI",
@@ -466,5 +472,40 @@ struct ActionGenerator {
         guard let detector = try? NSDataDetector(types: NSTextCheckingResult.CheckingType.link.rawValue) else { return nil }
         let match = detector.firstMatch(in: text, range: NSRange(text.startIndex..., in: text))
         return match?.url?.absoluteString
+    }
+
+    /// Converts a `CaiShortcut` into an `ActionItem` for the action list.
+    /// Shared by `generateActions` (pinned shortcuts) and `ActionListWindow.filteredActions`
+    /// (filter-to-reveal) so the two paths stay in sync.
+    static func actionItem(
+        from sc: CaiShortcut,
+        clipboardText: String,
+        shortcut: Int
+    ) -> ActionItem {
+        let actionType: ActionType
+        let subtitle: String
+        switch sc.type {
+        case .prompt:
+            actionType = .llmAction(.custom(sc.value))
+            subtitle = sc.value
+        case .url:
+            actionType = .shortcutURL(sc.value)
+            let preview = String(clipboardText.prefix(20))
+            let suffix = clipboardText.count > 20 ? "…" : ""
+            subtitle = sc.value.replacingOccurrences(of: "%s", with: preview + suffix)
+        case .shell:
+            actionType = .shortcutShell(sc.value)
+            subtitle = sc.value
+        }
+
+        return ActionItem(
+            id: "shortcut_\(sc.id.uuidString)",
+            title: sc.name,
+            subtitle: subtitle,
+            icon: sc.type.icon,
+            shortcut: shortcut,
+            type: actionType,
+            autoReplaceSelection: sc.type == .prompt && sc.autoReplaceSelection
+        )
     }
 }

--- a/Cai/Cai/Views/ActionListWindow.swift
+++ b/Cai/Cai/Views/ActionListWindow.swift
@@ -108,40 +108,24 @@ struct ActionListWindow: View {
                     subtitle: action.subtitle,
                     icon: action.icon,
                     shortcut: shortcut,
-                    type: action.type
+                    type: action.type,
+                    autoReplaceSelection: action.autoReplaceSelection
                 ))
                 shortcut += 1
             }
         }
 
         // Add matching user shortcuts — any word prefix match on name.
-        let clipboardText = text
+        // Skip shortcuts already surfaced as pinned items in the searchable list.
+        let alreadyShown = Set(items.map(\.id))
         for sc in settings.shortcuts {
+            let id = "shortcut_\(sc.id.uuidString)"
+            guard !alreadyShown.contains(id) else { continue }
             if anyWordHasPrefix(sc.name, query: query) {
-                let actionType: ActionType
-                let subtitle: String
-                switch sc.type {
-                case .prompt:
-                    actionType = .llmAction(.custom(sc.value))
-                    subtitle = sc.value
-                case .url:
-                    actionType = .shortcutURL(sc.value)
-                    let preview = String(clipboardText.prefix(20))
-                    let suffix = clipboardText.count > 20 ? "…" : ""
-                    subtitle = sc.value.replacingOccurrences(of: "%s", with: preview + suffix)
-                case .shell:
-                    actionType = .shortcutShell(sc.value)
-                    subtitle = sc.value
-                }
-
-                items.append(ActionItem(
-                    id: "shortcut_\(sc.id.uuidString)",
-                    title: sc.name,
-                    subtitle: subtitle,
-                    icon: sc.type.icon,
-                    shortcut: shortcut,
-                    type: actionType,
-                    autoReplaceSelection: sc.type == .prompt && sc.autoReplaceSelection
+                items.append(ActionGenerator.actionItem(
+                    from: sc,
+                    clipboardText: text,
+                    shortcut: shortcut
                 ))
                 shortcut += 1
             }

--- a/Cai/Cai/Views/ShortcutsManagementView.swift
+++ b/Cai/Cai/Views/ShortcutsManagementView.swift
@@ -16,6 +16,7 @@ struct ShortcutsManagementView: View {
     @State private var formType: CaiShortcut.ShortcutType = .prompt
     @State private var formValue: String = ""
     @State private var formAutoReplace: Bool = false
+    @State private var formPinned: Bool = false
 
     var body: some View {
         VStack(spacing: 0) {
@@ -72,6 +73,8 @@ struct ShortcutsManagementView: View {
                             formName = ""
                             formType = .prompt
                             formValue = ""
+                            formAutoReplace = false
+                            formPinned = false
                             isAddingNew = true
                             WindowController.passThrough = true
                         }) {
@@ -179,9 +182,17 @@ struct ShortcutsManagementView: View {
 
             // Name + value preview
             VStack(alignment: .leading, spacing: 1) {
-                Text(shortcut.name)
-                    .font(.system(size: 13, weight: .medium))
-                    .foregroundColor(.caiTextPrimary)
+                HStack(spacing: 4) {
+                    Text(shortcut.name)
+                        .font(.system(size: 13, weight: .medium))
+                        .foregroundColor(.caiTextPrimary)
+                    if shortcut.pinned {
+                        Image(systemName: "pin.fill")
+                            .font(.system(size: 9, weight: .medium))
+                            .foregroundColor(.caiPrimary)
+                            .accessibilityLabel("Pinned to top of action list")
+                    }
+                }
 
                 Text(shortcut.value)
                     .font(.system(size: 11))
@@ -209,6 +220,7 @@ struct ShortcutsManagementView: View {
                 formType = shortcut.type
                 formValue = shortcut.value
                 formAutoReplace = shortcut.autoReplaceSelection
+                formPinned = shortcut.pinned
                 editingShortcutId = shortcut.id
                 WindowController.passThrough = true
             }) {
@@ -346,6 +358,21 @@ struct ShortcutsManagementView: View {
                 .controlSize(.mini)
             }
 
+            // Pin to top — applies to all types.
+            Toggle(isOn: $formPinned) {
+                VStack(alignment: .leading, spacing: 2) {
+                    Text("Pin to top")
+                        .font(.system(size: 11, weight: .medium))
+                        .foregroundColor(.caiTextPrimary)
+                    Text("Show this action above the built-ins and assign the first ⌘ numbers.")
+                        .font(.system(size: 10))
+                        .foregroundColor(.caiTextSecondary.opacity(0.6))
+                        .fixedSize(horizontal: false, vertical: true)
+                }
+            }
+            .toggleStyle(.switch)
+            .controlSize(.mini)
+
             // Save / Cancel buttons
             HStack(spacing: 8) {
                 Button("Cancel") {
@@ -399,7 +426,13 @@ struct ShortcutsManagementView: View {
         let autoReplace = formType == .prompt && formAutoReplace
 
         if isNew {
-            let shortcut = CaiShortcut(name: trimmedName, type: formType, value: trimmedValue, autoReplaceSelection: autoReplace)
+            let shortcut = CaiShortcut(
+                name: trimmedName,
+                type: formType,
+                value: trimmedValue,
+                autoReplaceSelection: autoReplace,
+                pinned: formPinned
+            )
             withAnimation(.easeInOut(duration: 0.15)) {
                 settings.shortcuts.append(shortcut)
             }
@@ -410,6 +443,7 @@ struct ShortcutsManagementView: View {
                 settings.shortcuts[index].type = formType
                 settings.shortcuts[index].value = trimmedValue
                 settings.shortcuts[index].autoReplaceSelection = autoReplace
+                settings.shortcuts[index].pinned = formPinned
             }
         }
 
@@ -426,6 +460,7 @@ struct ShortcutsManagementView: View {
         formType = .prompt
         formValue = ""
         formAutoReplace = false
+        formPinned = false
     }
 
     // MARK: - Share as Extension


### PR DESCRIPTION
Refs #21 (primary proposal). One of two PRs splitting this issue; the secondary "hide built-ins" change is in a separate PR so the two features can be reviewed independently.

## Summary
- Adds a `pinned: Bool` flag to `CaiShortcut` with a backwards-compatible decoder so existing persisted shortcuts default to `pinned=false`.
- New "Pin to top" toggle in the custom action editor (`ShortcutsManagementView`) plus a small pin glyph on pinned rows.
- Pinned shortcuts now appear at the top of the default action list and consume the first ⌘ numbers; Ask AI shifts down.
- Refactors the shortcut → `ActionItem` conversion into a shared `ActionGenerator.actionItem(from:clipboardText:shortcut:)` helper used by both the default-list path and the filter-to-reveal path so they stay in sync.

## Test plan
- [ ] Pin a custom prompt action → it appears at ⌘1; Ask AI is now ⌘2.
- [ ] Pin two actions → both consume ⌘1/⌘2 in list order; Ask AI shifts to ⌘3.
- [ ] Pin one of each type (prompt, URL, shell) → all execute correctly via ⌘N from the default list.
- [ ] Type-to-filter the pinned action's name → it still appears, no duplicate row.
- [ ] Quit + relaunch → pin state persists.
- [ ] Launch with old persisted shortcuts (no \`pinned\` key) → decode succeeds, all default to unpinned.

🤖 Generated with [Claude Code](https://claude.com/claude-code)