### PR TITLE
feat: allow hiding built-in actions from default list

### DIFF
--- a/Cai/Cai/Models/CaiSettings.swift
+++ b/Cai/Cai/Models/CaiSettings.swift
@@ -32,6 +32,7 @@ class CaiSettings: ObservableObject {
         static let aboutYou = "cai_aboutYou"
         static let clipboardHistorySize = "cai_clipboardHistorySize"
         static let installedExtensions = "cai_installedExtensions"
+        static let hiddenBuiltInActions = "cai_hiddenBuiltInActions"
         static let appearance = "cai_appearance"
         static let anthropicModelName = "cai_anthropicModelName"
         static let openRouterModelName = "cai_openRouterModelName"
@@ -143,6 +144,14 @@ class CaiSettings: ObservableObject {
     @Published var installedExtensions: Set<String> {
         didSet {
             defaults.set(Array(installedExtensions), forKey: Keys.installedExtensions)
+        }
+    }
+
+    /// `ActionItem.id` values (e.g. `"reply"`, `"summarize"`) the user has hidden
+    /// from the default action list. Hidden actions remain reachable via type-to-filter.
+    @Published var hiddenBuiltInActions: Set<String> {
+        didSet {
+            defaults.set(Array(hiddenBuiltInActions), forKey: Keys.hiddenBuiltInActions)
         }
     }
 
@@ -465,6 +474,9 @@ class CaiSettings: ObservableObject {
 
         let installedSlugs = defaults.stringArray(forKey: Keys.installedExtensions) ?? []
         self.installedExtensions = Set(installedSlugs)
+
+        let hiddenIds = defaults.stringArray(forKey: Keys.hiddenBuiltInActions) ?? []
+        self.hiddenBuiltInActions = Set(hiddenIds)
 
         // Default to true for launch at login — bool(forKey:) returns false when key is absent,
         // so we check if the key has ever been set explicitly.

--- a/Cai/Cai/Services/ActionGenerator.swift
+++ b/Cai/Cai/Services/ActionGenerator.swift
@@ -18,17 +18,20 @@ struct ActionGenerator {
     ) -> [ActionItem] {
         var items: [ActionItem] = []
         var shortcut = 1
+        let hidden = settings.hiddenBuiltInActions
 
-        // Ask AI (⌘1) — always first, for ALL content types
-        items.append(ActionItem(
-            id: "custom_prompt",
-            title: "Ask AI",
-            subtitle: text.isEmpty ? "Ask anything" : "Ask AI anything about this content",
-            icon: "bolt.fill",
-            shortcut: shortcut,
-            type: .customPrompt
-        ))
-        shortcut += 1
+        // Ask AI — first built-in, hideable.
+        if !hidden.contains("custom_prompt") {
+            items.append(ActionItem(
+                id: "custom_prompt",
+                title: "Ask AI",
+                subtitle: text.isEmpty ? "Ask anything" : "Ask AI anything about this content",
+                icon: "bolt.fill",
+                shortcut: shortcut,
+                type: .customPrompt
+            ))
+            shortcut += 1
+        }
 
         // Empty clipboard — only Ask AI + destinations (user can also Cmd+N or Cmd+0)
         if detection.type == .empty {
@@ -71,15 +74,17 @@ struct ActionGenerator {
 
         // MARK: Word
         case .word:
-            items.append(ActionItem(
-                id: "define_word",
-                title: "Define Word",
-                subtitle: "Look up definition",
-                icon: "character.book.closed",
-                shortcut: shortcut,
-                type: .llmAction(.define)
-            ))
-            shortcut += 1
+            if !hidden.contains("define_word") {
+                items.append(ActionItem(
+                    id: "define_word",
+                    title: "Define Word",
+                    subtitle: "Look up definition",
+                    icon: "character.book.closed",
+                    shortcut: shortcut,
+                    type: .llmAction(.define)
+                ))
+                shortcut += 1
+            }
 
         // MARK: Short Text, Long Text
         case .shortText, .longText:
@@ -199,7 +204,7 @@ struct ActionGenerator {
             shortcut = (items.last?.shortcut ?? 0) + 1
 
             // Summarize — only for longer text (≥100 chars)
-            if text.count >= 100 {
+            if text.count >= 100 && !hidden.contains("summarize") {
                 items.append(ActionItem(
                     id: "summarize",
                     title: "Summarize",
@@ -211,52 +216,60 @@ struct ActionGenerator {
                 shortcut += 1
             }
 
-            items.append(ActionItem(
-                id: "explain",
-                title: "Explain",
-                subtitle: "Get an explanation",
-                icon: "lightbulb",
-                shortcut: shortcut,
-                type: .llmAction(.explain)
-            ))
-            shortcut += 1
-
-            // Reply / Proofread — only for prose content (not meetings, addresses, or single words)
-            if isProse {
+            if !hidden.contains("explain") {
                 items.append(ActionItem(
-                    id: "reply",
-                    title: "Reply",
-                    subtitle: "Draft a reply",
-                    icon: "arrowshape.turn.up.left",
+                    id: "explain",
+                    title: "Explain",
+                    subtitle: "Get an explanation",
+                    icon: "lightbulb",
                     shortcut: shortcut,
-                    type: .llmAction(.reply)
-                ))
-                shortcut += 1
-
-                items.append(ActionItem(
-                    id: "proofread",
-                    title: "Fix Grammar",
-                    subtitle: "Fix grammar, spelling, and punctuation",
-                    icon: "pencil.and.outline",
-                    shortcut: shortcut,
-                    type: .llmAction(.proofread)
+                    type: .llmAction(.explain)
                 ))
                 shortcut += 1
             }
 
-            let lang = settings.translationLanguage
-            items.append(ActionItem(
-                id: "translate",
-                title: "Translate to \(lang)",
-                subtitle: nil,
-                icon: "globe",
-                shortcut: shortcut,
-                type: .llmAction(.translate(lang))
-            ))
-            shortcut += 1
+            // Reply / Proofread — only for prose content (not meetings, addresses, or single words)
+            if isProse {
+                if !hidden.contains("reply") {
+                    items.append(ActionItem(
+                        id: "reply",
+                        title: "Reply",
+                        subtitle: "Draft a reply",
+                        icon: "arrowshape.turn.up.left",
+                        shortcut: shortcut,
+                        type: .llmAction(.reply)
+                    ))
+                    shortcut += 1
+                }
+
+                if !hidden.contains("proofread") {
+                    items.append(ActionItem(
+                        id: "proofread",
+                        title: "Fix Grammar",
+                        subtitle: "Fix grammar, spelling, and punctuation",
+                        icon: "pencil.and.outline",
+                        shortcut: shortcut,
+                        type: .llmAction(.proofread)
+                    ))
+                    shortcut += 1
+                }
+            }
+
+            if !hidden.contains("translate") {
+                let lang = settings.translationLanguage
+                items.append(ActionItem(
+                    id: "translate",
+                    title: "Translate to \(lang)",
+                    subtitle: nil,
+                    icon: "globe",
+                    shortcut: shortcut,
+                    type: .llmAction(.translate(lang))
+                ))
+                shortcut += 1
+            }
 
             // Search — skip for long text (nobody searches a paragraph)
-            if !isLong {
+            if !isLong && !hidden.contains("search_web") {
                 items.append(ActionItem(
                     id: "search_web",
                     title: "Search Web",
@@ -265,13 +278,13 @@ struct ActionGenerator {
                     shortcut: shortcut,
                     type: .search(text)
                 ))
+                shortcut += 1
             }
 
             // URL+text: append Open in Browser after text actions
             if detection.type == .url,
                let urlString = detection.entities.url,
                let url = URL(string: urlString) {
-                shortcut += 1
                 items.append(ActionItem(
                     id: "open_url",
                     title: "Open in Browser",
@@ -280,6 +293,7 @@ struct ActionGenerator {
                     shortcut: shortcut,
                     type: .openURL(url)
                 ))
+                shortcut += 1
             }
         }
 
@@ -354,19 +368,32 @@ struct ActionGenerator {
             }
         }
 
-        if detection.type != .word {
-            let defineAction = ActionItem(
-                id: "define_word",
-                title: "Define Word",
-                subtitle: "Look up definition",
-                icon: "character.book.closed",
+        // Define Word — surface in filter-to-reveal even when the user has hidden it
+        // or when the content type isn't a single word.
+        let defineAction = ActionItem(
+            id: "define_word",
+            title: "Define Word",
+            subtitle: "Look up definition",
+            icon: "character.book.closed",
+            shortcut: 0,
+            type: .llmAction(.define)
+        )
+        if !seenIDs.contains(defineAction.id) {
+            seenIDs.insert(defineAction.id)
+            extras.append(defineAction)
+        }
+
+        // Ask AI — surface in filter-to-reveal even when hidden from the default list.
+        if !seenIDs.contains("custom_prompt") {
+            seenIDs.insert("custom_prompt")
+            extras.append(ActionItem(
+                id: "custom_prompt",
+                title: "Ask AI",
+                subtitle: text.isEmpty ? "Ask anything" : "Ask AI anything about this content",
+                icon: "bolt.fill",
                 shortcut: 0,
-                type: .llmAction(.define)
-            )
-            if !seenIDs.contains(defineAction.id) {
-                seenIDs.insert(defineAction.id)
-                extras.append(defineAction)
-            }
+                type: .customPrompt
+            ))
         }
 
         // Open in Browser — if text contains a URL but wasn't detected as URL type

--- a/Cai/Cai/Views/SettingsView.swift
+++ b/Cai/Cai/Views/SettingsView.swift
@@ -284,6 +284,20 @@ struct SettingsView: View {
                     .padding(.horizontal, 4)
                     .padding(.top, -8)
 
+                    // MARK: Built-in Actions Group
+                    // Per-action visibility toggles. Hidden actions stay accessible via type-to-filter.
+                    settingsGroup(title: "Built-in Actions") {
+                        VStack(alignment: .leading, spacing: 6) {
+                            ForEach(SettingsView.hideableBuiltInActions, id: \.id) { action in
+                                builtInActionToggle(label: action.label, id: action.id)
+                            }
+                            Text("Hidden actions stay accessible by typing to filter.")
+                                .font(.system(size: 10))
+                                .foregroundColor(.caiTextSecondary.opacity(0.6))
+                                .padding(.top, 4)
+                        }
+                    }
+
                     // MARK: Personalization Group
                     // Layered personalization — global "About You" context + per-app Context Snippets.
                     // Both layers feed into `LLMService.buildMessages` and get injected into every
@@ -787,6 +801,45 @@ struct SettingsView: View {
     }
 
     // MARK: - Navigation Row
+
+    // MARK: - Built-in Actions Visibility
+
+    /// Built-in actions the user can hide from the default action list.
+    /// IDs match `ActionItem.id` strings produced by `ActionGenerator`.
+    private struct HideableAction: Identifiable {
+        let id: String
+        let label: String
+    }
+
+    private static let hideableBuiltInActions: [HideableAction] = [
+        HideableAction(id: "custom_prompt", label: "Ask AI"),
+        HideableAction(id: "summarize", label: "Summarize"),
+        HideableAction(id: "explain", label: "Explain"),
+        HideableAction(id: "reply", label: "Reply"),
+        HideableAction(id: "proofread", label: "Fix Grammar"),
+        HideableAction(id: "translate", label: "Translate"),
+        HideableAction(id: "search_web", label: "Search Web"),
+        HideableAction(id: "define_word", label: "Define Word")
+    ]
+
+    private func builtInActionToggle(label: String, id: String) -> some View {
+        Toggle(isOn: Binding(
+            get: { !settings.hiddenBuiltInActions.contains(id) },
+            set: { isVisible in
+                if isVisible {
+                    settings.hiddenBuiltInActions.remove(id)
+                } else {
+                    settings.hiddenBuiltInActions.insert(id)
+                }
+            }
+        )) {
+            Text(label)
+                .font(.system(size: 12))
+                .foregroundColor(.caiTextPrimary)
+        }
+        .toggleStyle(.switch)
+        .controlSize(.mini)
+    }
 
     /// Apple Settings-style navigation row: label + optional count badge + chevron.
     private func navRow(label: String, count: Int = 0, total: Int? = nil, action: (() -> Void)? = nil) -> some View {


### PR DESCRIPTION
Refs #21 (secondary proposal). One of two PRs splitting this issue; the primary "pin custom actions" change is in a separate PR so the two features can be reviewed independently.

## Summary
- New "Built-in Actions" group in Settings with toggles for Ask AI, Summarize, Explain, Reply, Fix Grammar, Translate, Search Web, and Define Word.
- Adds `CaiSettings.hiddenBuiltInActions: Set<String>` (UserDefaults-backed) to persist visibility per action ID.
- Hidden actions are removed from the default action list but remain reachable via type-to-filter (\`generateAllActions\` always re-adds Ask AI / Define Word so filter-to-reveal still surfaces them).
- ⌘ numbers stay contiguous when actions are hidden — only increment after the action is actually appended.

## Test plan
- [ ] Toggle off "Reply" → it disappears from the default action list; ⌘ numbering for remaining items has no gap.
- [ ] Type "rep" with the action list open → Reply still appears via filter-to-reveal.
- [ ] Toggle off "Ask AI" → list starts at the next built-in; type "ask" still surfaces it.
- [ ] Toggle off all built-ins → default list shows only type-specific actions and destinations; typing reveals everything.
- [ ] Quit + relaunch → hidden state persists.

🤖 Generated with [Claude Code](https://claude.com/claude-code)