### PR TITLE
Fix custom OpenAI endpoint: tolerate base URLs ending in /v1

### DIFF
--- a/Cai/Cai/Models/CaiSettings.swift
+++ b/Cai/Cai/Models/CaiSettings.swift
@@ -190,6 +190,20 @@ class CaiSettings: ObservableObject {
     /// Transient (not persisted) — set during init if old `cai_builtInModelPath` key exists.
     var needsMLXMigration: Bool = false
 
+    /// Normalizes a user-entered OpenAI-compatible base URL so callers can
+    /// safely append `/v1/...`. Users routinely paste the full base_url ending
+    /// in `/v1` (what the OpenAI SDK, LM Studio, and every tutorial hand them)
+    /// or a reverse-proxy subpath like `/llama/v1`. Without this we'd build
+    /// `.../v1/v1/models` and silently get an empty model list.
+    /// See https://github.com/cai-layer/cai/issues/28.
+    static func normalizedEndpoint(_ raw: String) -> String {
+        var s = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+        if s.hasSuffix("/") { s.removeLast() }
+        if s.lowercased().hasSuffix("/v1") { s.removeLast(3) }
+        if s.hasSuffix("/") { s.removeLast() }
+        return s
+    }
+
     /// Resolved model base URL based on provider selection
     var modelURL: String {
         switch modelProvider {
@@ -204,7 +218,7 @@ class CaiSettings: ObservableObject {
         case .openrouter:
             return "https://openrouter.ai/api"
         case .custom:
-            return customModelURL
+            return Self.normalizedEndpoint(customModelURL)
         }
     }
 

--- a/Cai/Cai/Services/LLMService.swift
+++ b/Cai/Cai/Services/LLMService.swift
@@ -128,6 +128,17 @@ actor LLMService {
         let error: String?
     }
 
+    /// Extracts a human-readable message from an OpenAI-compatible error body,
+    /// which may be `{"error": "msg"}` (LM Studio) or
+    /// `{"error": {"message": "msg"}}` (OpenAI / OpenRouter). Returns nil when
+    /// the body carries no recognizable error.
+    nonisolated static func errorMessage(from json: [String: Any]?) -> String? {
+        guard let json else { return nil }
+        if let s = json["error"] as? String { return s }
+        if let obj = json["error"] as? [String: Any], let m = obj["message"] as? String { return m }
+        return nil
+    }
+
     /// Checks if the LLM server is reachable and has a loaded model.
     func checkStatus() async -> Status {
         let provider = await MainActor.run { CaiSettings.shared.modelProvider }
@@ -206,20 +217,32 @@ actor LLMService {
 
         do {
             let (data, response) = try await URLSession.shared.data(for: request)
-            guard let http = response as? HTTPURLResponse, http.statusCode == 200 else {
-                return Status(available: false, modelName: nil, error: "Server returned non-200")
+            guard let http = response as? HTTPURLResponse else {
+                return Status(available: false, modelName: nil, error: "Invalid response")
             }
+            guard http.statusCode == 200 else {
+                return Status(available: false, modelName: nil,
+                              error: "Server returned \(http.statusCode) for \(url.path)")
+            }
+            let json = (try? JSONSerialization.jsonObject(with: data)) as? [String: Any]
             // Extract first model name — required by some providers
-            if let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
-               let models = json["data"] as? [[String: Any]],
-               let first = models.first,
-               let modelId = first["id"] as? String {
-                cachedModelName = modelId
-                return Status(available: true, modelName: modelId, error: nil)
+            if let models = json?["data"] as? [[String: Any]] {
+                if let modelId = models.first?["id"] as? String {
+                    cachedModelName = modelId
+                    return Status(available: true, modelName: modelId, error: nil)
+                }
+                // Server is up but no models loaded
+                cachedModelName = nil
+                return Status(available: false, modelName: nil, error: "No models loaded")
             }
-            // Server is up but no models loaded
+            // 200 but no `data` array. Almost always a wrong path — e.g. an
+            // endpoint that already ends in /v1, producing /v1/v1/models, which
+            // some servers (LM Studio) answer 200 with an error body. Surface the
+            // URL and any server error instead of failing silently. See issue #28.
             cachedModelName = nil
-            return Status(available: false, modelName: nil, error: "No models loaded")
+            let detail = Self.errorMessage(from: json) ?? "no model list at \(url.path)"
+            return Status(available: false, modelName: nil,
+                          error: "Unexpected response from server (\(detail)) — check the endpoint URL")
         } catch {
             return Status(available: false, modelName: nil, error: error.localizedDescription)
         }

--- a/Cai/Cai/Views/SettingsView.swift
+++ b/Cai/Cai/Views/SettingsView.swift
@@ -16,6 +16,9 @@ struct SettingsView: View {
 
     /// LLM connection status — checked each time settings opens.
     @State private var llmConnected: Bool? = nil  // nil = checking
+    /// Last connection error from checkStatus, surfaced inline so a misconfigured
+    /// endpoint (wrong port, doubled /v1, auth failure) isn't a silent empty list.
+    @State private var llmStatusError: String? = nil
     /// Available models from the current provider
     @State private var availableModels: [String] = []
     /// Debounce task for LLM status checks (prevents API call storms during typing)
@@ -175,9 +178,19 @@ struct SettingsView: View {
                                             .font(.system(size: 12, design: .monospaced))
                                             .accessibilityLabel("Custom model URL")
 
-                                        Text("OpenAI-compatible endpoint")
+                                        Text("OpenAI-compatible base URL — with or without /v1")
                                             .font(.system(size: 11))
                                             .foregroundColor(.caiTextSecondary)
+
+                                        if !settings.modelURL.isEmpty {
+                                            Text("Reads models from \(settings.modelURL)/v1/models")
+                                                .font(.system(size: 10, design: .monospaced))
+                                                .foregroundColor(.caiTextSecondary.opacity(0.6))
+                                                .lineLimit(1)
+                                                .truncationMode(.middle)
+                                                .textSelection(.enabled)
+                                                .accessibilityLabel("Resolved model list URL")
+                                        }
                                     }
 
                                     // Model picker
@@ -204,6 +217,14 @@ struct SettingsView: View {
                                     Text("Select a model or leave on Auto-detect")
                                         .font(.system(size: 10))
                                         .foregroundColor(.caiTextSecondary.opacity(0.6))
+
+                                    if llmConnected == false, let err = llmStatusError, !err.isEmpty {
+                                        Text(err)
+                                            .font(.system(size: 10))
+                                            .foregroundColor(.orange)
+                                            .fixedSize(horizontal: false, vertical: true)
+                                            .accessibilityLabel("Connection error: \(err)")
+                                    }
 
                                     // API Key (optional, for cloud or auth-enabled servers)
                                     HStack(spacing: 6) {
@@ -922,6 +943,7 @@ struct SettingsView: View {
             guard !Task.isCancelled else { return }
             await MainActor.run {
                 llmConnected = status.available
+                llmStatusError = status.available ? nil : status.error
             }
         }
     }

--- a/Cai/CaiTests/LLMServiceTests.swift
+++ b/Cai/CaiTests/LLMServiceTests.swift
@@ -608,4 +608,89 @@ final class LLMServiceTests: XCTestCase {
         XCTAssertEqual(result, .skip)
     }
 
+    // MARK: - Endpoint Normalization (issue #28)
+
+    // The endpoint field is a base URL we append `/v1/...` onto. Users paste a
+    // bare host, a full base_url ending in `/v1`, a reverse-proxy subpath, or a
+    // stray trailing slash. All must normalize so we never build `/v1/v1/...`.
+
+    func testNormalizeBareHostUnchanged() {
+        XCTAssertEqual(CaiSettings.normalizedEndpoint("http://127.0.0.1:1234"),
+                       "http://127.0.0.1:1234")
+    }
+
+    func testNormalizeStripsTrailingV1() {
+        // The #28 shape (minus the proxy): user pastes the OpenAI base_url.
+        XCTAssertEqual(CaiSettings.normalizedEndpoint("http://127.0.0.1:1234/v1"),
+                       "http://127.0.0.1:1234")
+    }
+
+    func testNormalizeStripsTrailingV1WithSlash() {
+        XCTAssertEqual(CaiSettings.normalizedEndpoint("http://127.0.0.1:1234/v1/"),
+                       "http://127.0.0.1:1234")
+    }
+
+    func testNormalizePreservesReverseProxySubpath() {
+        // The literal #28 endpoint: http://IP:PORT/llama/v1 must resolve to
+        // /llama/v1/models, not /llama/v1/v1/models.
+        XCTAssertEqual(CaiSettings.normalizedEndpoint("http://10.0.0.5:8080/llama/v1"),
+                       "http://10.0.0.5:8080/llama")
+    }
+
+    func testNormalizeStripsTrailingSlash() {
+        XCTAssertEqual(CaiSettings.normalizedEndpoint("http://127.0.0.1:1234/"),
+                       "http://127.0.0.1:1234")
+    }
+
+    func testNormalizeTrimsWhitespace() {
+        XCTAssertEqual(CaiSettings.normalizedEndpoint("  http://127.0.0.1:1234/v1  "),
+                       "http://127.0.0.1:1234")
+    }
+
+    func testNormalizeIsCaseInsensitiveOnV1() {
+        XCTAssertEqual(CaiSettings.normalizedEndpoint("http://127.0.0.1:1234/V1"),
+                       "http://127.0.0.1:1234")
+    }
+
+    func testNormalizeDoesNotStripBareV1Token() {
+        // A host merely ending in "v1" (no slash separator) must be left alone.
+        XCTAssertEqual(CaiSettings.normalizedEndpoint("http://myv1"),
+                       "http://myv1")
+    }
+
+    func testNormalizedEndpointProducesSingleV1ModelsPath() {
+        // Integration assertion: base + "/v1/models" has exactly one /v1, whatever
+        // the user typed. This is the regression that issue #28 is about.
+        let inputs = [
+            "http://127.0.0.1:1234",
+            "http://127.0.0.1:1234/",
+            "http://127.0.0.1:1234/v1",
+            "http://127.0.0.1:1234/v1/",
+        ]
+        for input in inputs {
+            let resolved = "\(CaiSettings.normalizedEndpoint(input))/v1/models"
+            XCTAssertEqual(resolved, "http://127.0.0.1:1234/v1/models",
+                           "input \(input) must resolve to a single-/v1 models URL")
+        }
+    }
+
+    // MARK: - OpenAI-compatible error body extraction (issue #28)
+
+    func testErrorMessageFromStringBody() {
+        // LM Studio shape: {"error": "Unexpected endpoint or method. (GET /v1/v1/models)"}
+        let json: [String: Any] = ["error": "Unexpected endpoint or method."]
+        XCTAssertEqual(LLMService.errorMessage(from: json), "Unexpected endpoint or method.")
+    }
+
+    func testErrorMessageFromObjectBody() {
+        // OpenAI / OpenRouter shape: {"error": {"message": "...", "type": "..."}}
+        let json: [String: Any] = ["error": ["message": "Invalid API key", "type": "auth_error"]]
+        XCTAssertEqual(LLMService.errorMessage(from: json), "Invalid API key")
+    }
+
+    func testErrorMessageNilWhenAbsent() {
+        XCTAssertNil(LLMService.errorMessage(from: ["data": []]))
+        XCTAssertNil(LLMService.errorMessage(from: nil))
+    }
+
 }


### PR DESCRIPTION
## What
Custom OpenAI-compatible providers showed no models when the endpoint was entered as a full base URL ending in `/v1` (or a reverse-proxy subpath like `/llama/v1`). Reported in #28.

## Why it happened
The endpoint field is treated as a bare origin that we append `/v1/models` / `/v1/chat/completions` onto. Every other OpenAI client (SDK, LM Studio, tutorials) hands users a base_url that already ends in `/v1`, so a natural paste produced `…/v1/v1/models`. LM Studio answers that wrong path with `200 {"error":"Unexpected endpoint..."}`, so discovery — which only checked for `200` — sailed past, found no `data` array, and returned an empty list with no error shown.

## The fix (three moves)
1. **Fail loudly** — `checkStatus` rejects a 200 without a `data` array and surfaces the server error + the URL it called.
2. **Show the resolved URL** in Settings (`Reads models from …/v1/models`) so normalization isn't a black box.
3. **Normalize the endpoint** — strip a trailing `/v1` and slashes before appending, so bare host / `…/v1` / `…/llama/v1` / trailing-slash all resolve to a single `/v1`. Scoped to the Custom provider.

Side benefit: real connection errors (e.g. a stopped LM Studio) now show inline for LM Studio/Ollama too.

## Tests
12 new unit tests in `LLMServiceTests` (normalization table incl. the exact #28 subpath shape + error-body extraction). Full suite green locally.

## Not in this PR (needs a decision)
Plain HTTP to a *remote* host may also be blocked by App Transport Security — there's no `NSAppTransportSecurity` exception. Loopback works; a remote `http://IP` might not. The fix would be `NSAllowsArbitraryLoads` (app-wide security relaxation), parked pending the reporter's exact error code (`-1004` = this path bug; `-1022` = ATS).

Refs #28