### PR TITLE
feat: "Return to submit" keyboard preference (Enter to send, Shift+Enter for newline)

### DIFF
--- a/Cai/Cai.xcodeproj/project.pbxproj
+++ b/Cai/Cai.xcodeproj/project.pbxproj
@@ -86,6 +86,7 @@
 		CAI00414 /* BackgroundTaskTracker.swift in Sources */ = {isa = PBXBuildFile; fileRef = CAI00415 /* BackgroundTaskTracker.swift */; };
 		CAI00416 /* ChainExecutor.swift in Sources */ = {isa = PBXBuildFile; fileRef = CAI00417 /* ChainExecutor.swift */; };
 		CAI00420 /* ChainExecutorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CAI00421 /* ChainExecutorTests.swift */; };
+		CAI00524 /* EnterToSendTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CAI00525 /* EnterToSendTests.swift */; };
 		CAI00422 /* ChainStepsTokenField.swift in Sources */ = {isa = PBXBuildFile; fileRef = CAI00423 /* ChainStepsTokenField.swift */; };
 		CAI00424 /* ChainStep.swift in Sources */ = {isa = PBXBuildFile; fileRef = CAI00425 /* ChainStep.swift */; };
 		CAI00426 /* AppleShortcutsService.swift in Sources */ = {isa = PBXBuildFile; fileRef = CAI00427 /* AppleShortcutsService.swift */; };
@@ -185,6 +186,7 @@
 		CAI00415 /* BackgroundTaskTracker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BackgroundTaskTracker.swift; sourceTree = "<group>"; };
 		CAI00417 /* ChainExecutor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChainExecutor.swift; sourceTree = "<group>"; };
 		CAI00421 /* ChainExecutorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChainExecutorTests.swift; sourceTree = "<group>"; };
+		CAI00525 /* EnterToSendTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EnterToSendTests.swift; sourceTree = "<group>"; };
 		CAI00423 /* ChainStepsTokenField.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChainStepsTokenField.swift; sourceTree = "<group>"; };
 		CAI00425 /* ChainStep.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChainStep.swift; sourceTree = "<group>"; };
 		CAI00427 /* AppleShortcutsService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppleShortcutsService.swift; sourceTree = "<group>"; };
@@ -302,6 +304,7 @@
 				CAI00501 /* MLXInferenceTests.swift */,
 				CAI00413 /* TemplateEngineTests.swift */,
 				CAI00421 /* ChainExecutorTests.swift */,
+				CAI00525 /* EnterToSendTests.swift */,
 			);
 			path = CaiTests;
 			sourceTree = "<group>";
@@ -562,6 +565,7 @@
 				CAI00500 /* MLXInferenceTests.swift in Sources */,
 				CAI00412 /* TemplateEngineTests.swift in Sources */,
 				CAI00420 /* ChainExecutorTests.swift in Sources */,
+				CAI00524 /* EnterToSendTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Cai/Cai/Models/CaiSettings.swift
+++ b/Cai/Cai/Models/CaiSettings.swift
@@ -32,6 +32,7 @@ class CaiSettings: ObservableObject {
         static let hotKeyCombo = "cai_hotKeyCombo"
         static let aboutYou = "cai_aboutYou"
         static let clipboardHistorySize = "cai_clipboardHistorySize"
+        static let pressReturnToSend = "cai_pressReturnToSend"
         static let installedExtensions = "cai_installedExtensions"
         static let hiddenBuiltInActions = "cai_hiddenBuiltInActions"
         static let appearance = "cai_appearance"
@@ -183,6 +184,15 @@ class CaiSettings: ObservableObject {
         didSet {
             defaults.set(launchAtLogin, forKey: Keys.launchAtLogin)
             updateLaunchAtLogin(launchAtLogin)
+        }
+    }
+
+    /// When true, Return submits the Ask AI prompt and Shift+Return inserts a
+    /// newline. Default false (Cmd+Return submits, plain Return inserts a newline).
+    /// Cmd+Return always submits in both modes. Scoped to the Ask AI panel.
+    @Published var pressReturnToSend: Bool {
+        didSet {
+            defaults.set(pressReturnToSend, forKey: Keys.pressReturnToSend)
         }
     }
 
@@ -410,6 +420,8 @@ class CaiSettings: ObservableObject {
 
         self.crashReportingEnabled = defaults.bool(forKey: Keys.crashReportingEnabled)
         self.crashReportingPromptShown = defaults.bool(forKey: Keys.crashReportingPromptShown)
+
+        self.pressReturnToSend = defaults.bool(forKey: Keys.pressReturnToSend)
 
         self.hotKeyComboDict = defaults.dictionary(forKey: Keys.hotKeyCombo) as? [String: Int]
         self.aboutYou = defaults.string(forKey: Keys.aboutYou) ?? ""

--- a/Cai/Cai/Services/WindowController.swift
+++ b/Cai/Cai/Services/WindowController.swift
@@ -31,6 +31,14 @@ class WindowController: NSObject, ObservableObject {
     /// When true, printable keys update the filter text on selectionState.
     /// Set to true only when the action list screen is active.
     static var acceptsFilterInput = true
+
+    /// True when the active floating-window screen submits via the central key
+    /// monitor on a bare Return — the Ask AI box, the result follow-up, and the
+    /// MCP connector form. Combined with the global `pressReturnToSend` setting,
+    /// a bare Return submits instead of inserting a newline. Form editors built on
+    /// `MultilineTextEditor` (Destinations / Shortcuts / inline edit) honor the same
+    /// setting through `ForwardingTextView` rather than this flag.
+    static var submitScreenActive = false
     private var window: NSWindow?
     private var toastWindow: NSWindow?
     private var actions: [ActionItem] = []
@@ -46,6 +54,7 @@ class WindowController: NSObject, ObservableObject {
     private var cachedWindow: NSWindow?
     private var cachedText: String?
     private var cachedPassThrough: Bool = false
+    private var cachedSubmitScreenActive: Bool = false
     private var cachedDismissTime: Date?
     private var cacheCleanupTimer: Timer?
     private static let resumeTimeout: TimeInterval = 7
@@ -200,9 +209,11 @@ class WindowController: NSObject, ObservableObject {
             self.window = cached
             self.currentText = cachedText  // Restore so next hideWindow() can re-cache it
             Self.passThrough = cachedPassThrough
+            Self.submitScreenActive = cachedSubmitScreenActive
             self.cachedWindow = nil
             self.cachedText = nil
             self.cachedPassThrough = false
+            self.cachedSubmitScreenActive = false
             self.cachedDismissTime = nil
             cacheCleanupTimer?.invalidate()
             cacheCleanupTimer = nil
@@ -347,6 +358,7 @@ class WindowController: NSObject, ObservableObject {
             cachedWindow = window
             cachedText = currentText
             cachedPassThrough = Self.passThrough
+            cachedSubmitScreenActive = Self.submitScreenActive
             cachedDismissTime = Date()
 
             // Auto-destroy the cache after the resume timeout
@@ -356,6 +368,7 @@ class WindowController: NSObject, ObservableObject {
             }
         }
         Self.passThrough = false
+        Self.submitScreenActive = false
         Self.acceptsFilterInput = true
         window = nil
         currentText = nil
@@ -433,6 +446,11 @@ class WindowController: NSObject, ObservableObject {
         cachedWindow = nil
         cachedText = nil
         cachedDismissTime = nil
+        // Reset the cached screen-state flags too. The resume path only reads them
+        // when cachedWindow != nil (now nil), but don't leave them stale-true where
+        // a future code path could apply them to an unrelated window.
+        cachedPassThrough = false
+        cachedSubmitScreenActive = false
         cacheCleanupTimer?.invalidate()
         cacheCleanupTimer = nil
     }
@@ -469,6 +487,18 @@ class WindowController: NSObject, ObservableObject {
 
     // MARK: - Keyboard Handling
 
+    /// Whether a Return keypress should submit the active screen instead of
+    /// inserting a newline. Only a *bare* Return submits — any modifier (Shift,
+    /// Option, Control) inserts a newline. Cmd+Return is handled separately and
+    /// always submits. Shared by the window key monitor and `ForwardingTextView`
+    /// (the form editors) so the rule is identical everywhere. Pure and isolated
+    /// from the view so the decision is unit-testable.
+    static func returnSubmitsPrompt(pressReturnToSend: Bool, submitScreenActive: Bool, modifiers: NSEvent.ModifierFlags) -> Bool {
+        guard submitScreenActive, pressReturnToSend else { return false }
+        // CapsLock is intentionally ignored — only intentional modifiers block submit.
+        return modifiers.intersection([.shift, .option, .control, .command]).isEmpty
+    }
+
     private func handleKeyEvent(_ event: NSEvent) -> Bool {
         // ESC — post a "back" notification; the SwiftUI view decides
         // whether to go back to action list or dismiss entirely.
@@ -480,13 +510,18 @@ class WindowController: NSObject, ObservableObject {
             return true
         }
 
-        // Cmd+Return — always captured (submit in custom prompt, or copy result)
+        // Cmd+Return — captured only on screens that submit through this monitor
+        // (Ask AI, follow-up, MCP form). On the other text-input screens — the form
+        // editors built on MultilineTextEditor (Destinations / Shortcuts / inline
+        // edit) — let it flow to the responder chain so the form's own ⌘⏎ handler
+        // (ForwardingTextView / the Save button shortcut) fires instead of being
+        // swallowed here into a no-op.
         if event.keyCode == 36 && event.modifierFlags.contains(.command) {
-            NotificationCenter.default.post(
-                name: .caiCmdEnterPressed,
-                object: nil
-            )
-            return true
+            if Self.submitScreenActive {
+                NotificationCenter.default.post(name: .caiCmdEnterPressed, object: nil)
+                return true
+            }
+            return false
         }
 
         // Tab — trigger follow-up mode (only when no text editor is active)
@@ -501,11 +536,25 @@ class WindowController: NSObject, ObservableObject {
             return true
         }
 
-        // When a text editor is active, let plain Return and arrows pass through
-        // (Return adds newlines, arrows move cursor)
+        // When a text editor is active, plain Return normally inserts a newline
+        // and arrows move the cursor — let those pass through. Exception: in the
+        // Ask AI composer with "Press Return to send" on, a plain Return (no
+        // Shift) submits instead, and Shift+Return inserts the newline. Cmd+Return
+        // is handled above and always submits.
         if Self.passThrough {
-            if event.keyCode == 126 || event.keyCode == 125 || event.keyCode == 36 {
-                return false
+            if event.keyCode == 36 {  // Return
+                if Self.returnSubmitsPrompt(
+                    pressReturnToSend: CaiSettings.shared.pressReturnToSend,
+                    submitScreenActive: Self.submitScreenActive,
+                    modifiers: event.modifierFlags
+                ) {
+                    NotificationCenter.default.post(name: .caiCmdEnterPressed, object: nil)
+                    return true  // submit — swallow so no newline is inserted
+                }
+                return false  // newline (modified Return, setting off, or another screen)
+            }
+            if event.keyCode == 126 || event.keyCode == 125 {
+                return false  // arrows move the cursor
             }
         }
 

--- a/Cai/Cai/Views/CustomPromptView.swift
+++ b/Cai/Cai/Views/CustomPromptView.swift
@@ -20,6 +20,7 @@ struct CustomPromptView: View {
     let onSubmit: (String) -> Void
 
     @FocusState private var isPromptFocused: Bool
+    @ObservedObject private var settings = CaiSettings.shared
 
     var body: some View {
         VStack(spacing: 0) {
@@ -99,10 +100,12 @@ struct CustomPromptView: View {
             Divider()
                 .background(Color.caiDivider)
 
-            // Footer
+            // Footer — submit hint reflects the active mode live (the @Published
+            // setting drives a re-render). Shared with ResultView's follow-up
+            // footer via PromptSubmitHint so the two can't drift.
             HStack(spacing: 12) {
                 KeyboardHint(key: "Esc", label: "Back")
-                KeyboardHint(key: "⌘↵", label: "Submit")
+                PromptSubmitHint(pressReturnToSend: settings.pressReturnToSend)
                 Spacer()
             }
             .padding(.horizontal, 16)
@@ -110,13 +113,19 @@ struct CustomPromptView: View {
         }
         .onAppear {
             WindowController.passThrough = true
+            WindowController.submitScreenActive = true
             DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
                 isPromptFocused = true
             }
         }
         .onDisappear {
             WindowController.passThrough = false
+            WindowController.submitScreenActive = false
         }
+        // Fires on Cmd+Return, or on a bare Return when "Press Return to send" is on.
+        // Safe to act unconditionally: this view is only mounted while the composer
+        // is the active screen, so the other .caiCmdEnterPressed listener
+        // (ActionListWindow.handleCmdEnter) no-ops here.
         .onReceive(NotificationCenter.default.publisher(for: .caiCmdEnterPressed)) { _ in
             let trimmed = state.promptText.trimmingCharacters(in: .whitespacesAndNewlines)
             guard !trimmed.isEmpty else { return }

--- a/Cai/Cai/Views/KeyboardHint.swift
+++ b/Cai/Cai/Views/KeyboardHint.swift
@@ -21,3 +21,16 @@ struct KeyboardHint: View {
         .foregroundColor(.caiTextSecondary.opacity(0.6))
     }
 }
+
+/// Submit-key hint for the Ask AI prompt composers — the initial Ask AI box
+/// (CustomPromptView) and the follow-up input on a result (ResultView). Shared
+/// so the two footers stay in sync, and reflects the "Return to submit" setting:
+/// ON shows "↵ to send", OFF shows "⌘↵ to send". The Shift+Return-for-newline
+/// behavior is taught at the toggle in Settings, so it's omitted here.
+struct PromptSubmitHint: View {
+    let pressReturnToSend: Bool
+
+    var body: some View {
+        KeyboardHint(key: pressReturnToSend ? "↵" : "⌘↵", label: "to send")
+    }
+}

--- a/Cai/Cai/Views/MCPFormView.swift
+++ b/Cai/Cai/Views/MCPFormView.swift
@@ -58,6 +58,9 @@ struct MCPFormView: View {
 
     @FocusState private var focusedField: String?
 
+    /// Drives the footer submit hint live when "Return to submit" toggles.
+    @ObservedObject private var settings = CaiSettings.shared
+
     var body: some View {
         VStack(spacing: 0) {
             headerView
@@ -78,9 +81,13 @@ struct MCPFormView: View {
         }
         .onAppear {
             WindowController.passThrough = true
+            // This form submits on ⌘⏎ via handleCmdEnter → caiMCPFormSubmit, so it
+            // opts into "Return to submit": a bare Return submits when enabled.
+            WindowController.submitScreenActive = true
         }
         .onDisappear {
             WindowController.passThrough = false
+            WindowController.submitScreenActive = false
             Self.pickerDropdownOpen = false
         }
         .onReceive(NotificationCenter.default.publisher(for: .caiMCPFormSubmit)) { _ in
@@ -939,7 +946,7 @@ struct MCPFormView: View {
 
             HStack(spacing: 12) {
                 KeyboardHint(key: "Esc", label: "Back")
-                KeyboardHint(key: "⌘↩", label: commentOnIssue != nil ? "Add Comment" : actionConfig.confirmLabel)
+                KeyboardHint(key: settings.pressReturnToSend ? "↩" : "⌘↩", label: commentOnIssue != nil ? "Add Comment" : actionConfig.confirmLabel)
             }
         }
         .padding(.horizontal, 16)

--- a/Cai/Cai/Views/MultilineTextEditor.swift
+++ b/Cai/Cai/Views/MultilineTextEditor.swift
@@ -266,6 +266,31 @@ private final class ForwardingTextView: NSTextView {
         return super.performKeyEquivalent(with: event)
     }
 
+    /// When "Return to submit" is enabled, a bare Return commits the form just
+    /// like ⌘⏎ (Shift/Option/Control+Return still insert a newline). Uses the same
+    /// `WindowController.returnSubmitsPrompt` predicate as the floating-window
+    /// composer, so the rule is identical everywhere. `submitScreenActive: true`
+    /// because reaching here means we have an `onCommit` to fire.
+    override func keyDown(with event: NSEvent) {
+        if event.keyCode == 36, let onCommit = onCommit {  // Return
+            // ⌘⏎ always commits; a bare Return commits when "Return to submit" is on.
+            // (Shift/Option/Control+Return fall through to insert a newline.) ⌘⏎ is
+            // normally caught by performKeyEquivalent, but handle it here too so it
+            // works even if that path is pre-empted.
+            let onlyCommand = event.modifierFlags.intersection([.shift, .option, .control, .command]) == [.command]
+            let bareSubmit = WindowController.returnSubmitsPrompt(
+                pressReturnToSend: CaiSettings.shared.pressReturnToSend,
+                submitScreenActive: true,
+                modifiers: event.modifierFlags
+            )
+            if onlyCommand || bareSubmit {
+                onCommit()
+                return
+            }
+        }
+        super.keyDown(with: event)
+    }
+
     /// Esc → fire onCancel callback directly. Same rationale as ⌘⏎: the
     /// SwiftUI shortcut chain was being intercepted by Cai's window-level
     /// Esc handler before the form's Cancel button could see it.

--- a/Cai/Cai/Views/ResultView.swift
+++ b/Cai/Cai/Views/ResultView.swift
@@ -32,6 +32,9 @@ struct ResultView: View {
 
     @FocusState private var isFollowUpFocused: Bool
 
+    /// Drives the follow-up footer hint live when "Press Return to send" toggles.
+    @ObservedObject private var settings = CaiSettings.shared
+
     /// Async generator that produces the result string (non-streaming fallback).
     let generator: () async throws -> String
     /// Optional streaming generator — tokens appear progressively. Used for built-in MLX provider.
@@ -184,7 +187,7 @@ struct ResultView: View {
                 Spacer()
                 if !isLoading && error == nil {
                     if showFollowUpInput {
-                        KeyboardHint(key: "\u{2318}\u{21B5}", label: "Submit")
+                        PromptSubmitHint(pressReturnToSend: settings.pressReturnToSend)
                     } else {
                         if isFollowUpEnabled {
                             KeyboardHint(key: "\u{21E5}", label: "Follow up")
@@ -234,11 +237,15 @@ struct ResultView: View {
         .onChange(of: showFollowUpInput) { _, showing in
             if showing {
                 WindowController.passThrough = true
+                // The follow-up is an Ask AI composer too, so honor "Press Return
+                // to send" here exactly as in the initial Ask AI box.
+                WindowController.submitScreenActive = true
                 DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
                     isFollowUpFocused = true
                 }
             } else {
                 WindowController.passThrough = false
+                WindowController.submitScreenActive = false
                 isFollowUpFocused = false
             }
         }

--- a/Cai/Cai/Views/SettingsView.swift
+++ b/Cai/Cai/Views/SettingsView.swift
@@ -269,6 +269,7 @@ struct SettingsView: View {
                             .onChange(of: settings.customModelURL) { forceCheckLLMStatus(); fetchAvailableModels() }
                             .onChange(of: settings.modelName) { forceCheckLLMStatus() }
                         }
+
                     }
 
                     // MARK: Extensions Group
@@ -494,33 +495,28 @@ struct SettingsView: View {
 
                         settingsDivider
 
-                        HStack {
-                            Text("Launch at Login")
-                                .font(.system(size: 12))
-                                .foregroundColor(.caiTextPrimary)
-                            Spacer()
-                            Toggle("", isOn: $settings.launchAtLogin)
-                                .toggleStyle(.switch)
-                                .controlSize(.mini)
-                                .tint(.caiPrimary)
-                                .labelsHidden()
-                        }
-                        .accessibilityLabel("Launch Cai at login")
+                        settingsToggleRow(
+                            "Launch at Login",
+                            isOn: $settings.launchAtLogin,
+                            accessibilityLabel: "Launch Cai at login"
+                        )
 
                         settingsDivider
 
-                        HStack {
-                            Text("Crash Reports")
-                                .font(.system(size: 12))
-                                .foregroundColor(.caiTextPrimary)
-                            Spacer()
-                            Toggle("", isOn: $settings.crashReportingEnabled)
-                                .toggleStyle(.switch)
-                                .controlSize(.mini)
-                                .tint(.caiPrimary)
-                                .labelsHidden()
-                        }
-                        .accessibilityLabel("Send crash reports to help improve Cai")
+                        settingsToggleRow(
+                            "Crash Reports",
+                            isOn: $settings.crashReportingEnabled,
+                            accessibilityLabel: "Send crash reports to help improve Cai"
+                        )
+
+                        settingsDivider
+
+                        settingsToggleRow(
+                            "Return to submit",
+                            subtitle: "↵ to submit · ⇧↵ for a new line",
+                            isOn: $settings.pressReturnToSend,
+                            accessibilityLabel: "Use Return to submit; Shift-Return inserts a new line"
+                        )
 
                         settingsDivider
 
@@ -1050,6 +1046,32 @@ struct SettingsView: View {
     /// Lightweight divider between sections within a group.
     private var settingsDivider: some View {
         Divider().opacity(0.3).padding(.vertical, 8)
+    }
+
+    /// A standard settings toggle row: leading label, trailing mini switch.
+    /// The accessibility label sits on the Toggle itself (not the row) so VoiceOver
+    /// announces the control with a name — a bare `Toggle("", …).labelsHidden()`
+    /// otherwise reads as an unnamed switch.
+    private func settingsToggleRow(_ title: String, subtitle: String? = nil, isOn: Binding<Bool>, accessibilityLabel: String) -> some View {
+        HStack {
+            VStack(alignment: .leading, spacing: 2) {
+                Text(title)
+                    .font(.system(size: 12))
+                    .foregroundColor(.caiTextPrimary)
+                if let subtitle {
+                    Text(subtitle)
+                        .font(.system(size: 10))
+                        .foregroundColor(.caiTextSecondary.opacity(0.6))
+                }
+            }
+            Spacer()
+            Toggle("", isOn: isOn)
+                .toggleStyle(.switch)
+                .controlSize(.mini)
+                .tint(.caiPrimary)
+                .labelsHidden()
+                .accessibilityLabel(accessibilityLabel)
+        }
     }
 
     /// Individual settings section with title header and optional status badge.

--- a/Cai/CaiTests/EnterToSendTests.swift
+++ b/Cai/CaiTests/EnterToSendTests.swift
@@ -1,0 +1,96 @@
+import XCTest
+import AppKit
+@testable import Cai
+
+/// Unit tests for the app-wide "Return to submit" decision logic (issue #32).
+/// Exercises `WindowController.returnSubmitsPrompt`, the shared pure function the
+/// window key monitor and the form editors (`ForwardingTextView`) both use to
+/// decide submit-vs-newline for a Return. Only a *bare* Return submits; any
+/// modifier inserts a newline. (Cmd+Return is handled separately upstream and
+/// always submits, so it's not modeled here.)
+final class EnterToSendTests: XCTestCase {
+
+    // MARK: - Setting OFF (default): Return always inserts a newline
+
+    func testReturnInsertsNewlineWhenSettingOff() {
+        // Composer active, no modifiers — but the setting is off, so Return = newline.
+        XCTAssertFalse(
+            WindowController.returnSubmitsPrompt(
+                pressReturnToSend: false, submitScreenActive: true, modifiers: []
+            ),
+            "With the setting off, a bare Return must insert a newline, not submit."
+        )
+    }
+
+    func testShiftReturnInsertsNewlineWhenSettingOff() {
+        XCTAssertFalse(
+            WindowController.returnSubmitsPrompt(
+                pressReturnToSend: false, submitScreenActive: true, modifiers: [.shift]
+            )
+        )
+    }
+
+    // MARK: - Setting ON: a bare Return submits, Shift+Return inserts a newline
+
+    func testBareReturnSubmitsWhenSettingOnAndComposerActive() {
+        XCTAssertTrue(
+            WindowController.returnSubmitsPrompt(
+                pressReturnToSend: true, submitScreenActive: true, modifiers: []
+            ),
+            "With the setting on in an Ask AI composer, a bare Return must submit."
+        )
+    }
+
+    func testShiftReturnInsertsNewlineWhenSettingOn() {
+        XCTAssertFalse(
+            WindowController.returnSubmitsPrompt(
+                pressReturnToSend: true, submitScreenActive: true, modifiers: [.shift]
+            ),
+            "Shift+Return must always insert a newline, even with the setting on."
+        )
+    }
+
+    // MARK: - Setting ON: only a *bare* Return submits — other modifiers insert a newline
+
+    func testOptionReturnInsertsNewlineWhenSettingOn() {
+        XCTAssertFalse(
+            WindowController.returnSubmitsPrompt(
+                pressReturnToSend: true, submitScreenActive: true, modifiers: [.option]
+            ),
+            "Option+Return must insert a newline — only a bare Return submits."
+        )
+    }
+
+    func testControlReturnInsertsNewlineWhenSettingOn() {
+        XCTAssertFalse(
+            WindowController.returnSubmitsPrompt(
+                pressReturnToSend: true, submitScreenActive: true, modifiers: [.control]
+            ),
+            "Control+Return must insert a newline — only a bare Return submits."
+        )
+    }
+
+    func testCapsLockDoesNotBlockSubmitWhenSettingOn() {
+        // CapsLock isn't an intentional modifier for this gesture — a Return with
+        // only CapsLock active is still a "bare" Return and must submit.
+        XCTAssertTrue(
+            WindowController.returnSubmitsPrompt(
+                pressReturnToSend: true, submitScreenActive: true, modifiers: [.capsLock]
+            ),
+            "CapsLock must not block submit — only Shift/Option/Control do."
+        )
+    }
+
+    // MARK: - Scoping: the setting only affects the Ask AI composers
+
+    func testReturnInsertsNewlineOutsideComposerEvenWhenSettingOn() {
+        // Other text-input screens (destination/MCP/shortcut forms) must keep
+        // Return = newline regardless of the setting.
+        XCTAssertFalse(
+            WindowController.returnSubmitsPrompt(
+                pressReturnToSend: true, submitScreenActive: false, modifiers: []
+            ),
+            "Outside an Ask AI composer, Return must insert a newline even with the setting on."
+        )
+    }
+}


### PR DESCRIPTION
## What
Adds an optional **"Return to submit"** preference (Settings → General). When on, a bare **Return** submits and **Shift+Return** inserts a newline. Everywhere the app currently uses **⌘+Return** to submit. Off by default, so nothing changes for existing users unless they opt in. 

Closes #32. 

## Why
⌘+Return-to-submit isn't discoverable and doesn't match the muscle memory of chat-style apps. This makes Enter-to-send a global, opt-in preference rather than an Ask-AI-only tweak. 

## Where it applies
All six submit surfaces, driven by one shared decision: 
- Ask AI box & "New Chat" 
- Result follow-up 
- MCP connector form 
- Destination add/edit form 
- Custom shortcut form 
- Inline LLM directive editor (chain steps) 

## How
The submit-vs-newline rule lives in one pure function, `WindowController.returnSubmitsPrompt(...)` , consulted by both keyboard substrates: the floating-window key monitor (Ask AI / follow-up / MCP) and `ForwardingTextView` (the `MultilineTextEditor` forms). Rule: only a **bare** Return submits; Shift/Option/Control+Return insert a newline; ⌘+Return always submits. The setting (`CaiSettings.pressReturnToSend`) lives in General with a symbol subtitle. 

## Testing
- `EnterToSendTests` — 8 cases over the pure predicate (off/on, bare vs Shift/Option/Control/CapsLock, in/out of a submit screen). 
- Manual: verified all six surfaces in both toggle states — Enter submits when on, ⌘+Return submits in both states, Shift+Return inserts newlines. 

## Notes
- In the multi-field forms (MCP / Destinations / Shortcuts), with the setting on a bare Return submits the whole form and Shift+Return inserts a newline — the intended tradeoff for app-wide consistency. 
- Default off → zero behavior change until opted in. 