### PR TITLE
fix: serialize NSPasteboard access to stop the ⌥C / clipboard-poll AppHangs

### DIFF
--- a/Cai/Cai.xcodeproj/project.pbxproj
+++ b/Cai/Cai.xcodeproj/project.pbxproj
@@ -61,6 +61,7 @@
 		CAI00143 /* ShortcutRecorderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CAI00144 /* ShortcutRecorderView.swift */; };
 		CAI00145 /* KeychainHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = CAI00146 /* KeychainHelper.swift */; };
 		CAI00147 /* OCRService.swift in Sources */ = {isa = PBXBuildFile; fileRef = CAI00148 /* OCRService.swift */; };
+		CAI00522 /* PasteboardQueue.swift in Sources */ = {isa = PBXBuildFile; fileRef = CAI00523 /* PasteboardQueue.swift */; };
 		CAI00150 /* Sparkle in Frameworks */ = {isa = PBXBuildFile; productRef = CAI00151 /* Sparkle */; };
 		CAI00160 /* Yams in Frameworks */ = {isa = PBXBuildFile; productRef = CAI00161 /* Yams */; };
 		CAI00163 /* ExtensionParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = CAI00164 /* ExtensionParser.swift */; };
@@ -163,6 +164,7 @@
 		CAI00144 /* ShortcutRecorderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShortcutRecorderView.swift; sourceTree = "<group>"; };
 		CAI00146 /* KeychainHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeychainHelper.swift; sourceTree = "<group>"; };
 		CAI00148 /* OCRService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OCRService.swift; sourceTree = "<group>"; };
+		CAI00523 /* PasteboardQueue.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PasteboardQueue.swift; sourceTree = "<group>"; };
 		CAI00164 /* ExtensionParser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExtensionParser.swift; sourceTree = "<group>"; };
 		CAI00165 /* GitHubIcon.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitHubIcon.swift; sourceTree = "<group>"; };
 		CAI00168 /* ExtensionService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExtensionService.swift; sourceTree = "<group>"; };
@@ -275,6 +277,7 @@
 				CAI00139 /* CrashReportingService.swift */,
 				CAI00146 /* KeychainHelper.swift */,
 				CAI00148 /* OCRService.swift */,
+				CAI00523 /* PasteboardQueue.swift */,
 				CAI00164 /* ExtensionParser.swift */,
 				CAI00168 /* ExtensionService.swift */,
 				CAI00183 /* MCPClientService.swift */,
@@ -530,6 +533,7 @@
 				CAI00138 /* CrashReportingService.swift in Sources */,
 				CAI00145 /* KeychainHelper.swift in Sources */,
 				CAI00147 /* OCRService.swift in Sources */,
+				CAI00522 /* PasteboardQueue.swift in Sources */,
 				CAI00163 /* ExtensionParser.swift in Sources */,
 				CAI00166 /* GitHubIcon.swift in Sources */,
 				CAI00196 /* LinearIcon.swift in Sources */,

--- a/Cai/Cai/AppDelegate.swift
+++ b/Cai/Cai/AppDelegate.swift
@@ -299,20 +299,22 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     /// snippets. Both are captured at hotkey time before Cmd+C simulation steals focus.
     @MainActor
     private func openWithClipboard(sourceApp: String? = nil, sourceBundleId: String? = nil) async {
-        // Pasteboard reads run off the main thread via PasteboardQueue, so a slow
-        // daemon (Universal Clipboard, huge item) can't freeze the runloop. The
-        // window still shows after the read completes; the difference is the app
-        // stays responsive while waiting.
+        // One atomic snapshot off the main thread (PasteboardQueue), then resolve
+        // off the lane. A slow daemon (Universal Clipboard, huge item) can't freeze
+        // the runloop, and detection sees a single consistent clipboard state
+        // rather than a mix from several separate reads.
+        let (content, changeCount) = await clipboardService.readClipboardContent()
 
-        // 1. Image file on clipboard (e.g. Finder copy of a .png/.jpg) — OCR it
-        //    Must come before text check: Finder puts both file URL and path text on the pasteboard,
-        //    so readClipboard() would match the path string and skip OCR.
-        if let ocrText = await OCRService.shared.extractTextFromClipboardImageFile() {
+        switch content {
+        // Image (file OCR or image data). For a Finder copy the file URL wins over
+        // the path string; if OCR finds no text, readClipboardContent falls through
+        // to the path text, so we never land here with empty OCR.
+        case .imageText(let ocrText):
             showImageOCRResult(ocrText: ocrText, sourceApp: sourceApp, sourceBundleId: sourceBundleId)
 
-        // 2. Text found
-        } else if let content = await clipboardService.readClipboard() {
-            clipboardHistory.recordCurrentClipboard(content)
+        // Text found.
+        case .text(let text):
+            clipboardHistory.recordCurrentClipboard(text, changeCount: changeCount)
 
             // No clamping here: ClipboardHistory already stores only the first
             // `maxTextLength` (10K) chars for its own UI, and `LLMService.truncateMessages`
@@ -320,31 +322,21 @@ class AppDelegate: NSObject, NSApplicationDelegate {
             // LLM cap from ever engaging and silently cut useful context for long
             // summaries. The action list header surfaces a subtle "X chars → 50K
             // for AI" note when the clipboard exceeds the LLM cap.
-            let detection = contentDetector.detect(content)
+            let detection = contentDetector.detect(text)
             print("Detected: \(detection.type.rawValue) (confidence: \(detection.confidence))")
             CrashReportingService.shared.addBreadcrumb(category: "content", message: "Detected: \(detection.type.rawValue)")
 
             windowController.showActionWindow(
-                text: content,
+                text: text,
                 detection: detection,
                 sourceApp: sourceApp,
                 sourceBundleId: sourceBundleId
             )
 
-        // 3. Image data on clipboard (e.g. Preview copy, screenshot to clipboard) — OCR it
-        } else if let ocrText = await OCRService.shared.extractTextFromClipboardImage() {
-            showImageOCRResult(ocrText: ocrText, sourceApp: sourceApp, sourceBundleId: sourceBundleId)
-
-        // 4/5. No text. Open an empty window either way; the image probes only
-        //      pick which log line to print.
-        } else {
-            let hasImage = await OCRService.shared.hasImageOnClipboard()
-            let hasImageFile = await OCRService.shared.hasImageFileOnClipboard()
-            if hasImage || hasImageFile {
-                print("No text found in clipboard image — opening window")
-            } else {
-                print("Clipboard is empty — opening window")
-            }
+        // No usable content — open an empty window. `hadImage` only picks the log line.
+        case .empty(let hadImage):
+            print(hadImage ? "No text found in clipboard image — opening window"
+                           : "Clipboard is empty — opening window")
             showEmptyWindow(sourceApp: sourceApp, sourceBundleId: sourceBundleId)
         }
     }
@@ -425,6 +417,10 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     }
 
     func applicationWillTerminate(_ notification: Notification) {
+        // Drain any pending pasteboard writes (fire-and-forget copies) so a copy
+        // made right before ⌘Q isn't lost when the process exits.
+        PasteboardQueue.shared.flush()
+
         // Safety net: unload MLX model if process is killed without going through quitApp()
         Task { await MLXInference.shared.unload() }
 

--- a/Cai/Cai/AppDelegate.swift
+++ b/Cai/Cai/AppDelegate.swift
@@ -201,7 +201,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         // Use whatever is already on the clipboard — don't simulate Cmd+C
         // because by the time the user clicks this menu item, the frontmost
         // app is Cai itself (or the menu bar), not the app with selected text.
-        openWithClipboard()
+        Task { @MainActor in await openWithClipboard() }
     }
 
     func showShortcutsWindow() {
@@ -297,16 +297,22 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     /// `sourceApp` is the display name ("Terminal"). `sourceBundleId` is the canonical
     /// key ("com.apple.Terminal") used by `ContextSnippetsManager` to match per-app
     /// snippets. Both are captured at hotkey time before Cmd+C simulation steals focus.
-    private func openWithClipboard(sourceApp: String? = nil, sourceBundleId: String? = nil) {
+    @MainActor
+    private func openWithClipboard(sourceApp: String? = nil, sourceBundleId: String? = nil) async {
+        // Pasteboard reads run off the main thread via PasteboardQueue, so a slow
+        // daemon (Universal Clipboard, huge item) can't freeze the runloop. The
+        // window still shows after the read completes; the difference is the app
+        // stays responsive while waiting.
+
         // 1. Image file on clipboard (e.g. Finder copy of a .png/.jpg) — OCR it
         //    Must come before text check: Finder puts both file URL and path text on the pasteboard,
         //    so readClipboard() would match the path string and skip OCR.
-        if let ocrText = OCRService.shared.extractTextFromClipboardImageFile() {
+        if let ocrText = await OCRService.shared.extractTextFromClipboardImageFile() {
             showImageOCRResult(ocrText: ocrText, sourceApp: sourceApp, sourceBundleId: sourceBundleId)
 
         // 2. Text found
-        } else if let content = clipboardService.readClipboard() {
-            clipboardHistory.recordCurrentClipboard()
+        } else if let content = await clipboardService.readClipboard() {
+            clipboardHistory.recordCurrentClipboard(content)
 
             // No clamping here: ClipboardHistory already stores only the first
             // `maxTextLength` (10K) chars for its own UI, and `LLMService.truncateMessages`
@@ -326,17 +332,19 @@ class AppDelegate: NSObject, NSApplicationDelegate {
             )
 
         // 3. Image data on clipboard (e.g. Preview copy, screenshot to clipboard) — OCR it
-        } else if let ocrText = OCRService.shared.extractTextFromClipboardImage() {
+        } else if let ocrText = await OCRService.shared.extractTextFromClipboardImage() {
             showImageOCRResult(ocrText: ocrText, sourceApp: sourceApp, sourceBundleId: sourceBundleId)
 
-        // 4. Image present but OCR found no text — still open window
-        } else if OCRService.shared.hasImageOnClipboard() || OCRService.shared.hasImageFileOnClipboard() {
-            print("No text found in clipboard image — opening window")
-            showEmptyWindow(sourceApp: sourceApp, sourceBundleId: sourceBundleId)
-
-        // 5. Nothing on clipboard — still open window
+        // 4/5. No text. Open an empty window either way; the image probes only
+        //      pick which log line to print.
         } else {
-            print("Clipboard is empty — opening window")
+            let hasImage = await OCRService.shared.hasImageOnClipboard()
+            let hasImageFile = await OCRService.shared.hasImageFileOnClipboard()
+            if hasImage || hasImageFile {
+                print("No text found in clipboard image — opening window")
+            } else {
+                print("Clipboard is empty — opening window")
+            }
             showEmptyWindow(sourceApp: sourceApp, sourceBundleId: sourceBundleId)
         }
     }
@@ -571,7 +579,9 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         // If nothing is selected, Cmd+C is a no-op and we fall back to
         // whatever is already on the clipboard.
         clipboardService.copySelectedText { [weak self] in
-            self?.openWithClipboard(sourceApp: sourceApp, sourceBundleId: sourceBundleId)
+            Task { @MainActor in
+                await self?.openWithClipboard(sourceApp: sourceApp, sourceBundleId: sourceBundleId)
+            }
         }
     }
 

--- a/Cai/Cai/Services/ClipboardHistory.swift
+++ b/Cai/Cai/Services/ClipboardHistory.swift
@@ -86,6 +86,10 @@ class ClipboardHistory: ObservableObject {
     /// Guards against a slow pasteboard daemon letting two poll ticks run their
     /// async content reads at the same time. Only mutated on the main thread.
     private var pollInFlight = false
+    /// Text just written by `copyEntry` (re-copying a history entry). The poll
+    /// suppresses the matching change once instead of re-recording it. Set and
+    /// checked on the main thread, so it can't race the poll.
+    private var suppressNextCopyText: String?
 
     // MARK: - Pin Persistence
 
@@ -128,34 +132,31 @@ class ClipboardHistory: ObservableObject {
         Task { @MainActor in
             defer { self.pollInFlight = false }
 
-            // 1. Image file on clipboard (e.g. Finder copy) — OCR takes priority over filename text.
-            if let ocrText = await OCRService.shared.extractTextFromClipboardImageFile() {
+            // One atomic snapshot (file → text → image priority), resolved off-lane.
+            let (content, _) = await ClipboardService.shared.readClipboardContent()
+            switch content {
+            case .imageText(let ocrText):
                 self.addEntry(ocrText, isImage: true)
-                return
-            }
-
-            // 2. Try text.
-            if let text = await PasteboardQueue.shared.read({ NSPasteboard.general.string(forType: .string) }) {
-                let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
-                if !trimmed.isEmpty {
-                    self.addEntry(trimmed)
-                    return
-                }
-            }
-
-            // 3. Image data on clipboard (no file, no text) — OCR.
-            if let ocrText = await OCRService.shared.extractTextFromClipboardImage() {
-                self.addEntry(ocrText, isImage: true)
+            case .text(let text):
+                // A history entry we just copied back surfaces here as a change.
+                // Clear the marker every text tick (bounding staleness) and skip
+                // recording when it matches the self-copy.
+                let suppressed = self.suppressNextCopyText
+                self.suppressNextCopyText = nil
+                guard text != suppressed else { return }
+                self.addEntry(text)
+            case .empty:
+                break
             }
         }
     }
 
-    /// Record a clipboard entry the caller already read (called from the ⌥C path
-    /// after `ClipboardService.readClipboard`). Takes the text directly to avoid
-    /// a redundant pasteboard read on the hot path. `changeCount` is cheap, so it
-    /// stays on the main thread.
-    func recordCurrentClipboard(_ text: String) {
-        lastChangeCount = NSPasteboard.general.changeCount
+    /// Record a clipboard entry the caller already read (the ⌥C path, from
+    /// `ClipboardService.readClipboardContent`). Takes the text AND the
+    /// `changeCount` from the same snapshot, so the poll baseline matches the
+    /// recorded content and the next poll tick won't re-record it.
+    func recordCurrentClipboard(_ text: String, changeCount: Int) {
+        lastChangeCount = changeCount
         let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !trimmed.isEmpty else { return }
         addEntry(trimmed)
@@ -203,15 +204,14 @@ class ClipboardHistory: ObservableObject {
     /// so the write can't race a concurrent read/paste-back. Fire-and-forget, so
     /// the call site stays synchronous.
     func copyEntry(_ entry: Entry) {
+        // Mark the text so the poll suppresses this self-copy instead of
+        // re-recording it. Set on main (this is called from the UI) and checked
+        // on main in `checkForChanges` — race-free, no cross-thread hop.
+        suppressNextCopyText = entry.text
         PasteboardQueue.shared.write {
             let pasteboard = NSPasteboard.general
             pasteboard.clearContents()
             pasteboard.setString(entry.text, forType: .string)
-            let newCount = pasteboard.changeCount
-            // Update the poll's baseline on main so it doesn't re-record this copy.
-            DispatchQueue.main.async { [weak self] in
-                self?.lastChangeCount = newCount
-            }
         }
     }
 

--- a/Cai/Cai/Services/ClipboardHistory.swift
+++ b/Cai/Cai/Services/ClipboardHistory.swift
@@ -83,6 +83,9 @@ class ClipboardHistory: ObservableObject {
 
     private var lastChangeCount: Int = 0
     private var pollTimer: Timer?
+    /// Guards against a slow pasteboard daemon letting two poll ticks run their
+    /// async content reads at the same time. Only mutated on the main thread.
+    private var pollInFlight = false
 
     // MARK: - Pin Persistence
 
@@ -107,52 +110,52 @@ class ClipboardHistory: ObservableObject {
 
     /// Check if the pasteboard has new content.
     ///
-    /// **Threading:** runs on the main thread (timer source). NSPasteboard is
-    /// not thread-safe, and previously dispatching the content reads to a
-    /// background queue (`app.cai.clipboard-history`) raced with main-thread
-    /// reads from `OCRService` / `ClipboardService` during ⌥C, crashing in
-    /// `__NSFastEnumerationMutationHandler` while AppKit was iterating
-    /// pasteboard types. Keeping everything on main eliminates that race.
-    ///
-    /// The cost is a possible runloop hang on a slow `pboardd` or huge
-    /// clipboard, but: (a) `changeCount` is cheap and short-circuits when
-    /// nothing changed; (b) actual content reads (`string(forType:)` /
-    /// Vision OCR) only fire when the clipboard truly changed (rare during
-    /// active use). If hangs become a real problem, the right next step is
-    /// a process-wide pasteboard lock — not another concurrent reader.
+    /// **Threading:** the timer fires on the main thread; the cheap `changeCount`
+    /// probe stays here (it is cached and does not iterate the items array). When
+    /// the count moves, the actual content reads (`string(forType:)` / Vision OCR)
+    /// run off the main thread on `PasteboardQueue`, so a slow `pboardd` or a huge
+    /// clipboard can no longer hang the runloop, and they are serialized against
+    /// the ⌥C path and paste-back — a single reader at a time, which is what the
+    /// previous "everything on main" workaround was protecting against (two
+    /// concurrent readers crashed in `__NSFastEnumerationMutationHandler`).
     private func checkForChanges() {
-        let pasteboard = NSPasteboard.general
-        let currentCount = pasteboard.changeCount
+        let currentCount = NSPasteboard.general.changeCount
 
-        guard currentCount != lastChangeCount else { return }
+        guard currentCount != lastChangeCount, !pollInFlight else { return }
         lastChangeCount = currentCount
+        pollInFlight = true
 
-        // 1. Image file on clipboard (e.g. Finder copy) — OCR takes priority over filename text.
-        if let ocrText = OCRService.shared.extractTextFromClipboardImageFile() {
-            addEntry(ocrText, isImage: true)
-            return
-        }
+        Task { @MainActor in
+            defer { self.pollInFlight = false }
 
-        // 2. Try text.
-        if let text = pasteboard.string(forType: .string) {
-            let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
-            if !trimmed.isEmpty {
-                addEntry(trimmed)
+            // 1. Image file on clipboard (e.g. Finder copy) — OCR takes priority over filename text.
+            if let ocrText = await OCRService.shared.extractTextFromClipboardImageFile() {
+                self.addEntry(ocrText, isImage: true)
                 return
             }
-        }
 
-        // 3. Image data on clipboard (no file, no text) — OCR.
-        if let ocrText = OCRService.shared.extractTextFromClipboardImage() {
-            addEntry(ocrText, isImage: true)
+            // 2. Try text.
+            if let text = await PasteboardQueue.shared.read({ NSPasteboard.general.string(forType: .string) }) {
+                let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
+                if !trimmed.isEmpty {
+                    self.addEntry(trimmed)
+                    return
+                }
+            }
+
+            // 3. Image data on clipboard (no file, no text) — OCR.
+            if let ocrText = await OCRService.shared.extractTextFromClipboardImage() {
+                self.addEntry(ocrText, isImage: true)
+            }
         }
     }
 
-    /// Manually record a clipboard entry (called from ClipboardService after copy)
-    func recordCurrentClipboard() {
-        let pasteboard = NSPasteboard.general
-        lastChangeCount = pasteboard.changeCount
-        guard let text = pasteboard.string(forType: .string) else { return }
+    /// Record a clipboard entry the caller already read (called from the ⌥C path
+    /// after `ClipboardService.readClipboard`). Takes the text directly to avoid
+    /// a redundant pasteboard read on the hot path. `changeCount` is cheap, so it
+    /// stays on the main thread.
+    func recordCurrentClipboard(_ text: String) {
+        lastChangeCount = NSPasteboard.general.changeCount
         let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !trimmed.isEmpty else { return }
         addEntry(trimmed)
@@ -196,12 +199,20 @@ class ClipboardHistory: ObservableObject {
         }
     }
 
-    /// Copy a history entry back to the clipboard
+    /// Copy a history entry back to the clipboard. Routed through PasteboardQueue
+    /// so the write can't race a concurrent read/paste-back. Fire-and-forget, so
+    /// the call site stays synchronous.
     func copyEntry(_ entry: Entry) {
-        let pasteboard = NSPasteboard.general
-        pasteboard.clearContents()
-        pasteboard.setString(entry.text, forType: .string)
-        lastChangeCount = pasteboard.changeCount  // Don't re-record this as a new entry
+        PasteboardQueue.shared.write {
+            let pasteboard = NSPasteboard.general
+            pasteboard.clearContents()
+            pasteboard.setString(entry.text, forType: .string)
+            let newCount = pasteboard.changeCount
+            // Update the poll's baseline on main so it doesn't re-record this copy.
+            DispatchQueue.main.async { [weak self] in
+                self?.lastChangeCount = newCount
+            }
+        }
     }
 
     // MARK: - Pinning

--- a/Cai/Cai/Services/ClipboardService.swift
+++ b/Cai/Cai/Services/ClipboardService.swift
@@ -119,7 +119,11 @@ class ClipboardService {
     /// Requirements: Accessibility permission, App Sandbox disabled. Keycode
     /// for V is 9 (kVK_ANSI_V).
     func pasteResult(_ text: String, toBundleId bundleId: String?, completion: @escaping (PasteOutcome) -> Void) {
-        let pasteboard = NSPasteboard.general
+        // Completion always fires on main — callers update UI from it. Defined
+        // first so every exit (including the preflight failure) routes through it.
+        let finish: (PasteOutcome) -> Void = { outcome in
+            DispatchQueue.main.async { completion(outcome) }
+        }
 
         // Preflight: without accessibility, CGEventSource builds fine but the
         // posted event is silently dropped. Call AXIsProcessTrusted() directly
@@ -128,10 +132,13 @@ class ClipboardService {
         // so recently-revoked permission can still read as granted.
         guard AXIsProcessTrusted() else {
             print("❌ Paste aborted — accessibility permission missing")
-            completion(.failed)
+            finish(.failed)
             return
         }
 
+        // Frontmost detection and app activation are AppKit-main-affine, so
+        // resolve them here on the calling thread (always main). Only the
+        // pasteboard byte ops below run on the serial queue.
         let frontmostBundleId = NSWorkspace.shared.frontmostApplication?.bundleIdentifier
         let caiBundleId = Bundle.main.bundleIdentifier
         let sourceIsFrontmost = bundleId != nil && bundleId == frontmostBundleId
@@ -141,10 +148,13 @@ class ClipboardService {
         // force-activate the source (would leak AI output into the wrong
         // context, e.g. Slack DM with the wrong person). Copy instead.
         if !sourceIsFrontmost && !caiIsFrontmost && bundleId != nil {
-            pasteboard.clearContents()
-            pasteboard.setString(text, forType: .string)
-            print("📋 User moved from \(bundleId ?? "nil") to \(frontmostBundleId ?? "unknown"); copied for manual paste")
-            completion(.copiedForManualPaste)
+            PasteboardQueue.shared.write {
+                let pasteboard = NSPasteboard.general
+                pasteboard.clearContents()
+                pasteboard.setString(text, forType: .string)
+                print("📋 User moved from \(bundleId ?? "nil") to \(frontmostBundleId ?? "unknown"); copied for manual paste")
+                finish(.copiedForManualPaste)
+            }
             return
         }
 
@@ -162,7 +172,15 @@ class ClipboardService {
             activationDelay = 0
         }
 
-        DispatchQueue.main.asyncAfter(deadline: .now() + activationDelay) {
+        // Snapshot -> set -> Cmd+V -> conditional restore runs as ONE serial-queue
+        // block, holding the pasteboard lane from snapshot through restore so a
+        // second concurrent paste-back can't interleave and clobber the clipboard.
+        PasteboardQueue.shared.write {
+            if activationDelay > 0 {
+                Thread.sleep(forTimeInterval: activationDelay)
+            }
+
+            let pasteboard = NSPasteboard.general
             let snapshot = PasteboardSnapshot(pasteboard)
             pasteboard.clearContents()
             pasteboard.setString(text, forType: .string)
@@ -173,7 +191,7 @@ class ClipboardService {
                   let keyUp = CGEvent(keyboardEventSource: eventSource, virtualKey: 9, keyDown: false) else {
                 print("❌ Failed to create CGEvent for paste")
                 snapshot.restore(to: pasteboard)
-                completion(.failed)
+                finish(.failed)
                 return
             }
 
@@ -184,16 +202,15 @@ class ClipboardService {
 
             print("⌨️ Posted Cmd+V via CGEvent to \(bundleId ?? "frontmost app")")
 
-            // Fire completion immediately so the caller can dismiss UI. Run the
-            // snapshot restore detached — 400ms is enough for fast apps (~50ms)
-            // through slow Electron (~200ms). Skip the restore if changeCount
-            // moved (another process wrote during the window).
-            completion(.pasted)
+            // Fire completion immediately so the caller can dismiss UI, then keep
+            // holding the lane through the restore window. 400ms is enough for
+            // fast apps (~50ms) through slow Electron (~200ms). Skip the restore
+            // if changeCount moved (another process wrote during the window).
+            finish(.pasted)
 
-            DispatchQueue.main.asyncAfter(deadline: .now() + 0.4) {
-                if pasteboard.changeCount == ourChangeCount {
-                    snapshot.restore(to: pasteboard)
-                }
+            Thread.sleep(forTimeInterval: 0.4)
+            if pasteboard.changeCount == ourChangeCount {
+                snapshot.restore(to: pasteboard)
             }
         }
     }
@@ -235,10 +252,14 @@ class ClipboardService {
 
     /// Reads text content from the system clipboard
     /// - Returns: Trimmed text content, or nil if clipboard is empty or doesn't contain text
-    func readClipboard() -> String? {
-        let pasteboard = NSPasteboard.general
+    ///
+    /// Runs the read on `PasteboardQueue` (off the main thread) so a slow
+    /// pasteboard daemon — e.g. Universal Clipboard fetching a paired-device
+    /// copy — can't freeze the ⌥C hot path.
+    func readClipboard() async -> String? {
+        let content = await PasteboardQueue.shared.read { NSPasteboard.general.string(forType: .string) }
 
-        guard let content = pasteboard.string(forType: .string) else {
+        guard let content else {
             print("📋 Clipboard is empty or doesn't contain text")
             return nil
         }

--- a/Cai/Cai/Services/ClipboardService.swift
+++ b/Cai/Cai/Services/ClipboardService.swift
@@ -1,6 +1,14 @@
 import AppKit
 import Carbon
 
+/// Fully-resolved clipboard content for the ⌥C / history-poll detection path,
+/// in priority order. Produced from ONE atomic pasteboard snapshot.
+enum ClipboardContent {
+    case imageText(String)      // OCR text from an image file OR image data
+    case text(String)           // trimmed, non-empty plain text
+    case empty(hadImage: Bool)  // nothing usable; hadImage only picks the log line
+}
+
 class ClipboardService {
     static let shared = ClipboardService()
 
@@ -275,5 +283,56 @@ class ClipboardService {
         // API keys, or other secrets that must never leave the process.
         print("📋 Clipboard read: \(trimmed.count) chars")
         return trimmed
+    }
+
+    /// Reads everything the detection path needs in ONE PasteboardQueue hop, then
+    /// resolves it (OCR + disk image load) OFF the lane. Replaces the previous
+    /// chain of separate async reads, which weren't atomic — a write landing
+    /// between them let the ⌥C window / history poll act on a mix of two clipboard
+    /// states. Returns the resolved content plus the `changeCount` observed in the
+    /// same snapshot, so callers set their poll baseline from the same read.
+    func readClipboardContent() async -> (content: ClipboardContent, changeCount: Int) {
+        // Capture raw materials in a SINGLE lane occupancy — pasteboard reads only.
+        // No OCR, no disk I/O, and no nested PasteboardQueue call (re-entering the
+        // serial queue would self-deadlock).
+        let capture: RawClipboardCapture = await PasteboardQueue.shared.read {
+            let pb = NSPasteboard.general
+            let fileURLs = (pb.readObjects(forClasses: [NSURL.self], options: [
+                NSPasteboard.ReadingOptionKey.urlReadingFileURLsOnly: true
+            ]) as? [URL]) ?? []
+            return RawClipboardCapture(
+                fileURLs: fileURLs,
+                text: pb.string(forType: .string),
+                image: NSImage(pasteboard: pb),
+                changeCount: pb.changeCount
+            )
+        }
+
+        // Resolve OFF the lane, preserving the original priority: image file
+        // (OCR; nil → fall through, since Finder puts BOTH a file URL and the path
+        // string) > plain text > image data > empty.
+        if let ocrText = OCRService.shared.ocrImageFiles(capture.fileURLs) {
+            return (.imageText(ocrText), capture.changeCount)
+        }
+        if let raw = capture.text {
+            let trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+            if !trimmed.isEmpty {
+                return (.text(trimmed), capture.changeCount)
+            }
+        }
+        if let image = capture.image, let ocrText = OCRService.shared.ocrImage(image) {
+            return (.imageText(ocrText), capture.changeCount)
+        }
+        let hadImage = capture.image != nil
+            || capture.fileURLs.contains { OCRService.imageExtensions.contains($0.pathExtension.lowercased()) }
+        return (.empty(hadImage: hadImage), capture.changeCount)
+    }
+
+    /// Raw clipboard materials captured in one lane occupancy, resolved off-lane.
+    private struct RawClipboardCapture {
+        let fileURLs: [URL]
+        let text: String?
+        let image: NSImage?
+        let changeCount: Int
     }
 }

--- a/Cai/Cai/Services/OCRService.swift
+++ b/Cai/Cai/Services/OCRService.swift
@@ -10,68 +10,73 @@ class OCRService {
     /// Attempts to read an image from the clipboard and extract text via Vision OCR.
     /// Returns the extracted text, or nil if no image is found or no text is recognized.
     /// Supports all image formats macOS handles: PNG, JPEG, TIFF, HEIC, BMP, GIF, WebP, etc.
-    func extractTextFromClipboardImage() -> String? {
-        let pasteboard = NSPasteboard.general
-
-        // NSImage(pasteboard:) handles all image formats macOS supports
-        guard let image = NSImage(pasteboard: pasteboard),
-              let cgImage = cgImage(from: image) else {
-            return nil
+    func extractTextFromClipboardImage() async -> String? {
+        // Pasteboard read + Vision both run on PasteboardQueue: the read is
+        // serialized off-main (no hang, no concurrent-reader crash), and OCR
+        // only fires on a real clipboard change so the brief lane occupancy
+        // (~50-200ms) is acceptable.
+        await PasteboardQueue.shared.read {
+            // NSImage(pasteboard:) handles all image formats macOS supports
+            guard let image = NSImage(pasteboard: NSPasteboard.general),
+                  let cgImage = self.cgImage(from: image) else {
+                return nil
+            }
+            return self.performOCR(on: cgImage)
         }
-
-        return performOCR(on: cgImage)
     }
 
     /// Checks if the clipboard contains a file URL pointing to an image file (e.g. Finder copy).
     /// If so, loads the image and performs OCR. Returns nil if not an image file or no text found.
-    func extractTextFromClipboardImageFile() -> String? {
-        let pasteboard = NSPasteboard.general
-
-        guard let urls = pasteboard.readObjects(forClasses: [NSURL.self], options: [
-            NSPasteboard.ReadingOptionKey.urlReadingFileURLsOnly: true
-        ]) as? [URL] else {
-            return nil
-        }
-
-        let imageExtensions: Set<String> = [
-            "png", "jpg", "jpeg", "tiff", "tif", "heic", "heif", "bmp", "gif", "webp"
-        ]
-
-        for url in urls {
-            guard imageExtensions.contains(url.pathExtension.lowercased()),
-                  let image = NSImage(contentsOf: url),
-                  let cgImg = cgImage(from: image) else {
-                continue
+    func extractTextFromClipboardImageFile() async -> String? {
+        await PasteboardQueue.shared.read {
+            guard let urls = NSPasteboard.general.readObjects(forClasses: [NSURL.self], options: [
+                NSPasteboard.ReadingOptionKey.urlReadingFileURLsOnly: true
+            ]) as? [URL] else {
+                return nil
             }
 
-            #if DEBUG
-            print("OCR: Loading image file: \(url.lastPathComponent)")
-            #endif
+            let imageExtensions: Set<String> = [
+                "png", "jpg", "jpeg", "tiff", "tif", "heic", "heif", "bmp", "gif", "webp"
+            ]
 
-            return performOCR(on: cgImg)
+            for url in urls {
+                guard imageExtensions.contains(url.pathExtension.lowercased()),
+                      let image = NSImage(contentsOf: url),
+                      let cgImg = self.cgImage(from: image) else {
+                    continue
+                }
+
+                #if DEBUG
+                print("OCR: Loading image file: \(url.lastPathComponent)")
+                #endif
+
+                return self.performOCR(on: cgImg)
+            }
+
+            return nil
         }
-
-        return nil
     }
 
     /// Lightweight check: is there an image on the clipboard? (No OCR performed)
     /// Used for the "No text found in image" toast path.
-    func hasImageOnClipboard() -> Bool {
-        return NSImage(pasteboard: NSPasteboard.general) != nil
+    func hasImageOnClipboard() async -> Bool {
+        await PasteboardQueue.shared.read { NSImage(pasteboard: NSPasteboard.general) != nil }
     }
 
     /// Lightweight check: is there an image file URL on the clipboard? (No OCR performed)
-    func hasImageFileOnClipboard() -> Bool {
-        guard let urls = NSPasteboard.general.readObjects(forClasses: [NSURL.self], options: [
-            NSPasteboard.ReadingOptionKey.urlReadingFileURLsOnly: true
-        ]) as? [URL] else {
-            return false
-        }
+    func hasImageFileOnClipboard() async -> Bool {
+        await PasteboardQueue.shared.read {
+            guard let urls = NSPasteboard.general.readObjects(forClasses: [NSURL.self], options: [
+                NSPasteboard.ReadingOptionKey.urlReadingFileURLsOnly: true
+            ]) as? [URL] else {
+                return false
+            }
 
-        let imageExtensions: Set<String> = [
-            "png", "jpg", "jpeg", "tiff", "tif", "heic", "heif", "bmp", "gif", "webp"
-        ]
-        return urls.contains { imageExtensions.contains($0.pathExtension.lowercased()) }
+            let imageExtensions: Set<String> = [
+                "png", "jpg", "jpeg", "tiff", "tif", "heic", "heif", "bmp", "gif", "webp"
+            ]
+            return urls.contains { imageExtensions.contains($0.pathExtension.lowercased()) }
+        }
     }
 
     // MARK: - Private

--- a/Cai/Cai/Services/OCRService.swift
+++ b/Cai/Cai/Services/OCRService.swift
@@ -7,76 +7,38 @@ class OCRService {
     static let shared = OCRService()
     private init() {}
 
-    /// Attempts to read an image from the clipboard and extract text via Vision OCR.
-    /// Returns the extracted text, or nil if no image is found or no text is recognized.
-    /// Supports all image formats macOS handles: PNG, JPEG, TIFF, HEIC, BMP, GIF, WebP, etc.
-    func extractTextFromClipboardImage() async -> String? {
-        // Pasteboard read + Vision both run on PasteboardQueue: the read is
-        // serialized off-main (no hang, no concurrent-reader crash), and OCR
-        // only fires on a real clipboard change so the brief lane occupancy
-        // (~50-200ms) is acceptable.
-        await PasteboardQueue.shared.read {
-            // NSImage(pasteboard:) handles all image formats macOS supports
-            guard let image = NSImage(pasteboard: NSPasteboard.general),
-                  let cgImage = self.cgImage(from: image) else {
-                return nil
+    /// Image file extensions OCR can load. Single source of truth, shared with the
+    /// clipboard reader's file-URL filter (`ClipboardService.readClipboardContent`).
+    static let imageExtensions: Set<String> = [
+        "png", "jpg", "jpeg", "tiff", "tif", "heic", "heif", "bmp", "gif", "webp"
+    ]
+
+    /// OCRs the first loadable image file in `urls`, returning its recognized text
+    /// (or nil if none qualify or no text is found). Pure CPU + disk work, no
+    /// pasteboard access — run it OFF the PasteboardQueue lane after the URLs have
+    /// been captured, so Vision/disk I/O don't occupy the shared lane.
+    func ocrImageFiles(_ urls: [URL]) -> String? {
+        for url in urls {
+            guard Self.imageExtensions.contains(url.pathExtension.lowercased()),
+                  let image = NSImage(contentsOf: url),
+                  let cgImg = cgImage(from: image) else {
+                continue
             }
-            return self.performOCR(on: cgImage)
+
+            #if DEBUG
+            print("OCR: Loading image file: \(url.lastPathComponent)")
+            #endif
+
+            return performOCR(on: cgImg)
         }
+        return nil
     }
 
-    /// Checks if the clipboard contains a file URL pointing to an image file (e.g. Finder copy).
-    /// If so, loads the image and performs OCR. Returns nil if not an image file or no text found.
-    func extractTextFromClipboardImageFile() async -> String? {
-        await PasteboardQueue.shared.read {
-            guard let urls = NSPasteboard.general.readObjects(forClasses: [NSURL.self], options: [
-                NSPasteboard.ReadingOptionKey.urlReadingFileURLsOnly: true
-            ]) as? [URL] else {
-                return nil
-            }
-
-            let imageExtensions: Set<String> = [
-                "png", "jpg", "jpeg", "tiff", "tif", "heic", "heif", "bmp", "gif", "webp"
-            ]
-
-            for url in urls {
-                guard imageExtensions.contains(url.pathExtension.lowercased()),
-                      let image = NSImage(contentsOf: url),
-                      let cgImg = self.cgImage(from: image) else {
-                    continue
-                }
-
-                #if DEBUG
-                print("OCR: Loading image file: \(url.lastPathComponent)")
-                #endif
-
-                return self.performOCR(on: cgImg)
-            }
-
-            return nil
-        }
-    }
-
-    /// Lightweight check: is there an image on the clipboard? (No OCR performed)
-    /// Used for the "No text found in image" toast path.
-    func hasImageOnClipboard() async -> Bool {
-        await PasteboardQueue.shared.read { NSImage(pasteboard: NSPasteboard.general) != nil }
-    }
-
-    /// Lightweight check: is there an image file URL on the clipboard? (No OCR performed)
-    func hasImageFileOnClipboard() async -> Bool {
-        await PasteboardQueue.shared.read {
-            guard let urls = NSPasteboard.general.readObjects(forClasses: [NSURL.self], options: [
-                NSPasteboard.ReadingOptionKey.urlReadingFileURLsOnly: true
-            ]) as? [URL] else {
-                return false
-            }
-
-            let imageExtensions: Set<String> = [
-                "png", "jpg", "jpeg", "tiff", "tif", "heic", "heif", "bmp", "gif", "webp"
-            ]
-            return urls.contains { imageExtensions.contains($0.pathExtension.lowercased()) }
-        }
+    /// OCRs an already-captured image. Pure CPU work, no pasteboard access — run
+    /// it OFF the PasteboardQueue lane.
+    func ocrImage(_ image: NSImage) -> String? {
+        guard let cgImage = cgImage(from: image) else { return nil }
+        return performOCR(on: cgImage)
     }
 
     // MARK: - Private

--- a/Cai/Cai/Services/OutputDestinationService.swift
+++ b/Cai/Cai/Services/OutputDestinationService.swift
@@ -31,9 +31,9 @@ actor OutputDestinationService {
         case .pasteBack:
             try await executePasteBack(text: text, sourceBundleId: sourceBundleId)
         case .clipboardCopy:
-            // Trivial sync write — bounce to MainActor since NSPasteboard is
-            // documented as main-thread-bound for write coalescing.
-            await MainActor.run {
+            // Route through PasteboardQueue so the write serializes with every
+            // other pasteboard op (no concurrent access with reads/paste-back).
+            PasteboardQueue.shared.write {
                 NSPasteboard.general.clearContents()
                 NSPasteboard.general.setString(text, forType: .string)
             }

--- a/Cai/Cai/Services/PasteboardQueue.swift
+++ b/Cai/Cai/Services/PasteboardQueue.swift
@@ -1,0 +1,49 @@
+import AppKit
+
+/// Process-wide serializer for every `NSPasteboard.general` content read/write.
+///
+/// Why this exists: `NSPasteboard` is not thread-safe, and a synchronous content
+/// read can block for seconds on the pasteboard daemon (`pbs`) when the system is
+/// fetching a Universal Clipboard / Handoff item over the network, or for a large
+/// or promise-backed item. Doing those reads on the main thread froze the Option+C
+/// hot path and the clipboard-history poll (Sentry AppHangs on 1.5.0).
+///
+/// Funnelling every access onto ONE serial queue does two things at once:
+///   1. moves the blocking read off the main thread, so the runloop never hangs;
+///   2. guarantees a single reader/writer at a time, which the previous
+///      "everything on main" workaround was protecting against -- two concurrent
+///      readers crashed in `__NSFastEnumerationMutationHandler` while AppKit was
+///      iterating pasteboard types.
+///
+/// Deliberately a serial `DispatchQueue`, NOT an `actor`: paste-back must hold the
+/// pasteboard exclusively across a ~0.4s restore window, and a Swift actor releases
+/// isolation at every `await` (reentrancy), so a second paste-back would interleave
+/// and clobber the clipboard. A serial-queue block holds the lane from entry to
+/// return. Do NOT convert this to an actor.
+///
+/// Invariant: every pasteboard content touch in the app goes through `read` or
+/// `write`. Never call back into the queue from inside a queue block -- a serial
+/// queue would self-deadlock. (Cheap `changeCount` probes may stay on the caller's
+/// thread: that property is cached and does not iterate the items array.)
+final class PasteboardQueue {
+    static let shared = PasteboardQueue()
+    private init() {}
+
+    private let queue = DispatchQueue(label: "com.soyasis.cai.pasteboard", qos: .userInitiated)
+
+    /// Runs `body` on the serial pasteboard queue and returns its result. The
+    /// `await` suspends off the main thread, so a slow pasteboard daemon never
+    /// blocks the runloop.
+    func read<T>(_ body: @escaping () -> T) async -> T {
+        await withCheckedContinuation { continuation in
+            queue.async { continuation.resume(returning: body()) }
+        }
+    }
+
+    /// Runs `body` on the serial pasteboard queue, fire-and-forget, so callers
+    /// (SwiftUI views, menu actions) stay synchronous. The write still serializes
+    /// against every other pasteboard operation.
+    func write(_ body: @escaping () -> Void) {
+        queue.async(execute: body)
+    }
+}

--- a/Cai/Cai/Services/PasteboardQueue.swift
+++ b/Cai/Cai/Services/PasteboardQueue.swift
@@ -46,4 +46,11 @@ final class PasteboardQueue {
     func write(_ body: @escaping () -> Void) {
         queue.async(execute: body)
     }
+
+    /// Blocks the caller until every queued operation has finished. Call on app
+    /// termination so a fire-and-forget write (a copy made right before ⌘Q) isn't
+    /// lost when the process exits before the queue drains.
+    func flush() {
+        queue.sync {}
+    }
 }

--- a/Cai/Cai/Services/SystemActions.swift
+++ b/Cai/Cai/Services/SystemActions.swift
@@ -118,8 +118,12 @@ struct SystemActions {
     // MARK: - Clipboard
 
     static func copyToClipboard(_ text: String) {
-        let pasteboard = NSPasteboard.general
-        pasteboard.clearContents()
-        pasteboard.setString(text, forType: .string)
+        // Routed through PasteboardQueue so the write serializes against every
+        // other pasteboard op. Fire-and-forget keeps this call site synchronous.
+        PasteboardQueue.shared.write {
+            let pasteboard = NSPasteboard.general
+            pasteboard.clearContents()
+            pasteboard.setString(text, forType: .string)
+        }
     }
 }


### PR DESCRIPTION
## What

Routes every `NSPasteboard` access through a single serial queue so clipboard reads no longer block the main thread — fixing the 1.5.0 AppHang timeouts (Sentry) while keeping the no-concurrent-readers guarantee.

## Why

On 1.5.0 a synchronous pasteboard read on the main thread could block for seconds on `pboardd` — fetching a Universal Clipboard / Handoff item over the network, or a large or promise-backed item — freezing the ⌥C hot path and the clipboard-history poll. The previous "everything on main" approach avoided a separate crash (two concurrent readers crashing in `__NSFastEnumerationMutationHandler`) but is exactly what left the main thread exposed to those hangs.

## How

- New `PasteboardQueue`: a process-wide serial `DispatchQueue` that funnels every pasteboard content read/write. Reads are `async` (off-main, so a slow daemon never hangs the runloop), writes are fire-and-forget but still serialized, and `flush()` drains pending writes on quit so a copy made right before ⌘Q isn't lost.
- The ⌥C / history-poll detection takes ONE atomic snapshot per call (file URLs + text + image + `changeCount` in a single hop) and resolves off the lane — OCR and disk loads run after the read returns. A write landing mid-detection can no longer make the window act on a mix of two clipboard states, and Vision OCR doesn't occupy the shared lane.
- Cheap `changeCount` probes stay on the caller's thread (the property is cached and doesn't iterate the items array).

## Testing

- Build + unit tests pass.
- Manual matrix on a real device: plain text, URL, image file (with and without OCR-able text), screenshot image data, empty clipboard, clipboard-history re-copy, copy-then-⌘Q, a ~23 MB clipboard, and a rapid ⌥C + paste-back stress pass (no crash, no hang).
- Universal Clipboard / Handoff — the original freeze trigger — ⌥C no longer hangs.

## Notes

- Paste-back holds the serial lane for ~0.4s after each paste (its restore window). It's bounded and only delays a ⌥C fired immediately after a paste-back — kept deliberately, because freeing the lane would let a back-to-back paste-back restore the wrong clipboard.
- Re-copying a clipboard-history entry floats it to most-recent (standard clipboard-manager behavior).