### PR TITLE
fix: keep explicitly-chosen provider when it's unavailable at launch (#35)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -91,6 +91,10 @@ iOSInjectionProject/
 # Build artifacts
 *.dmg
 
+# Code coverage (LLVM profiling data from instrumented Debug runs)
+*.profraw
+*.profdata
+
 # Claude Code (local settings, memory, plans — user-specific)
 .claude/
 

--- a/Cai/Cai/Models/CaiSettings.swift
+++ b/Cai/Cai/Models/CaiSettings.swift
@@ -115,6 +115,24 @@ class CaiSettings: ObservableObject {
         }
     }
 
+    /// True once a provider has been persisted — the user picked one, or first-launch
+    /// onboarding/auto-detect established one. When false (fresh install, or a legacy
+    /// user who never had a provider key) auto-detect may probe for a running provider.
+    /// When true, auto-detect must be skipped: a provider that is merely unavailable at
+    /// launch (Apple Intelligence on macOS < 26, a local server not started yet, an offline
+    /// cloud provider) would otherwise be silently reverted to built-in and persisted. See #35.
+    var hasExplicitProvider: Bool {
+        Self.providerIsExplicit(persistedValue: defaults.object(forKey: Keys.modelProvider))
+    }
+
+    /// Pure predicate behind `hasExplicitProvider`, extracted for unit tests (see #35).
+    /// "Explicit" means the provider key has been persisted at all — by a user choice or
+    /// by first-launch onboarding/auto-detect. Presence is what matters, not the value:
+    /// even a persisted `.builtIn` counts, so auto-detect won't re-run and revert it.
+    static func providerIsExplicit(persistedValue: Any?) -> Bool {
+        persistedValue != nil
+    }
+
     /// Only used when modelProvider == .custom
     @Published var customModelURL: String {
         didSet { defaults.set(customModelURL, forKey: Keys.customModelURL) }
@@ -647,6 +665,15 @@ class CaiSettings: ObservableObject {
     /// Probes known provider URLs and selects the first one that responds.
     /// Only call this when `hasExplicitProvider` is false (first launch).
     func autoDetectProvider() async {
+        // Respect an explicitly chosen provider. Auto-detect is a first-launch / legacy
+        // convenience; once a provider is persisted, a transient unavailability at launch
+        // must never silently revert the user to built-in (see #35). Enforced here so no
+        // caller can reintroduce the override.
+        if hasExplicitProvider {
+            print("Provider explicitly set — skipping auto-detect")
+            return
+        }
+
         // Apple Intelligence — highest priority, zero setup.
         // Only auto-select on subsequent launches (builtInSetupDone already true).
         // On first launch, the ModelSetupView handles the Apple Intelligence recommendation

--- a/Cai/CaiTests/CaiSettingsTests.swift
+++ b/Cai/CaiTests/CaiSettingsTests.swift
@@ -1,0 +1,35 @@
+import XCTest
+@testable import Cai
+
+/// Regression tests for the "explicit provider" guard that stops launch-time
+/// auto-detect from silently reverting a chosen provider that is merely
+/// unavailable at launch (issue #35). Exercises `CaiSettings.providerIsExplicit`,
+/// the pure predicate behind `hasExplicitProvider` and the early-return guard in
+/// `autoDetectProvider()`.
+final class CaiSettingsTests: XCTestCase {
+
+    func testFreshInstallHasNoExplicitProvider() {
+        // No provider key ever persisted → not explicit → first-launch auto-detect may run.
+        XCTAssertFalse(
+            CaiSettings.providerIsExplicit(persistedValue: nil),
+            "A fresh install (no persisted provider) must allow first-launch auto-detect."
+        )
+    }
+
+    func testPersistedProviderIsExplicit() {
+        // User picked (or onboarding/auto-detect established) a provider.
+        XCTAssertTrue(
+            CaiSettings.providerIsExplicit(persistedValue: CaiSettings.ModelProvider.lmstudio.rawValue),
+            "A persisted provider must be treated as explicit so auto-detect is skipped."
+        )
+    }
+
+    func testPersistedBuiltInIsExplicit() {
+        // The subtle #35 case: a persisted Built-in still counts as explicit, so a
+        // provider that is only transiently unavailable is never re-detected and reverted.
+        XCTAssertTrue(
+            CaiSettings.providerIsExplicit(persistedValue: CaiSettings.ModelProvider.builtIn.rawValue),
+            "Even a persisted Built-in must be explicit — presence, not value, decides."
+        )
+    }
+}


### PR DESCRIPTION
## Summary

Fixes #35: an explicitly-chosen AI provider that's unavailable at launch is no longer silently reverted to the built-in model. Once a provider has been picked (by the user or by first-launch onboarding/auto-detect), a transient startup unavailability (Apple Intelligence on macOS < 26, a local server not started yet, an offline cloud provider) leaves the selection intact.

## What changed

- `autoDetectProvider()` early-returns when a provider is already persisted, so a failed launch-time status check can't fall through to the built-in fallback and clobber the choice.
- Added `hasExplicitProvider`, backed by a pure `providerIsExplicit(persistedValue:)` predicate (presence in defaults, not value), plus `CaiSettingsTests` covering fresh install, a persisted provider, and the persisted-built-in case.
- Ignored `*.profraw` / `*.profdata` (LLVM coverage artifacts).

## Testing

- Full test suite green, including the 3 new tests.
- Manual QA on Debug v1.5.2: with LM Studio unreachable at launch, console logged "skipping auto-detect" and the provider stayed put instead of reverting. Provider switching/persistence verified across Built-in, LM Studio, OpenRouter, Anthropic; smoke test clean, no watchdog or crashes.