### PR TITLE
feat: make snippets.json self-documenting and hot-reload on edit

### DIFF
--- a/Cai/Cai/AppDelegate.swift
+++ b/Cai/Cai/AppDelegate.swift
@@ -188,8 +188,10 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         // validated at launch. If the file is malformed, the toast fires immediately
         // instead of waiting for the user to trigger their first LLM action.
         // Deferred one runloop tick so the toast observer is ready to receive it.
-        DispatchQueue.main.async {
+        // Then start the directory watcher so later hand edits apply without a restart.
+        Task { @MainActor in
             _ = ContextSnippetsManager.shared
+            ContextSnippetsManager.shared.startWatching()
         }
     }
 

--- a/Cai/Cai/Services/ContextSnippetsManager.swift
+++ b/Cai/Cai/Services/ContextSnippetsManager.swift
@@ -4,9 +4,10 @@ import Foundation
 
 /// Manages per-app context snippets persisted to `~/.config/cai/snippets.json`.
 ///
-/// **v1 scope (this PR):** JSON-only, no inline editor UI. Power users edit
-/// the file directly. Changes require an app restart to take effect — documented
-/// at https://getcai.app/docs/usage/context-snippets/. Settings has a single
+/// **v1 scope:** JSON-only, no inline editor UI. Power users edit the file
+/// directly; a directory watcher reloads it on save (see `startWatching()`),
+/// so edits apply without restarting Cai. Docs:
+/// https://getcai.app/docs/usage/context-snippets/. Settings has a single
 /// "Open snippets.json in Finder" button for discoverability. The v1.1 UI will
 /// add in-memory CRUD methods and call `loadSnippets()` after saves.
 ///
@@ -55,8 +56,30 @@ class ContextSnippetsManager: ObservableObject {
         self.configDirectory = configDirectory ?? FileManager.default
             .homeDirectoryForCurrentUser
             .appendingPathComponent(".config/cai", isDirectory: true)
-        seedEmptyFileIfMissing()
+        seedStarterFileIfMissing()
         loadSnippets()
+    }
+
+    // MARK: - Live Reload
+
+    /// Watches `~/.config/cai/` and reloads snippets when the file changes, so
+    /// hand edits apply without restarting Cai. Reuses `PendingChangeWatcher`,
+    /// which is a generic debounced directory watcher despite its name (the
+    /// rename is deferred so the in-flight helper PR isn't churned). Watching
+    /// the directory rather than the file survives editors that save via
+    /// temp-file-plus-rename, which would orphan a file-descriptor watch.
+    private var watcher: PendingChangeWatcher?
+
+    /// Starts live reload. Called once from `AppDelegate` at launch after the
+    /// eager warm-up. MainActor because the watcher delivers on the main queue
+    /// and `snippets` drives SwiftUI.
+    @MainActor func startWatching() {
+        guard watcher == nil else { return }
+        let watcher = PendingChangeWatcher(directory: configDirectory) { [weak self] in
+            self?.loadSnippets()
+        }
+        watcher.start()
+        self.watcher = watcher
     }
 
     // MARK: - Persistence
@@ -107,30 +130,43 @@ class ContextSnippetsManager: ObservableObject {
         }
     }
 
-    /// Writes a minimal valid JSON file on first run so power users can find it
-    /// when poking around `~/.config/cai/`. The help doc has the full schema and
-    /// copy-paste examples.
+    /// Writes a starter file on first run so the file teaches its own schema:
+    /// a `_docs` link plus one disabled example entry. A power user who opens
+    /// it (Settings → Open in Finder) sees the exact shape to copy instead of
+    /// an empty array. The example ships `enabled: false`, so seeding never
+    /// changes behavior; flipping it on, or copying the entry, is the tutorial.
     ///
-    /// We explicitly do NOT seed with an example snippet because JSON doesn't
-    /// support comments (a `_comment` field would be decoded as unknown), and a
-    /// commented example next to the array can't survive a JSON parser. Examples
-    /// belong in the docs page (linked from Settings → Open snippets.json), where
-    /// they can be properly formatted, explained, and updated.
+    /// `_docs` is an unknown key to `ContextSnippetsFile` and `JSONDecoder`
+    /// ignores unknown keys, so it survives parsing untouched. The underscore
+    /// prefix keeps it out of any future real schema field's namespace.
     ///
-    /// Note: as of the JSON-ergonomics fix, snippets only require `bundleId`,
-    /// `appName`, and `context` — `id` and `enabled` are optional in the file.
-    /// See `ContextSnippet.init(from:)` for the custom decoder.
-    private func seedEmptyFileIfMissing() {
+    /// Deliberately NO comments in the seed: strict JSON has none, and the
+    /// v1.1 editor UI will rewrite this file through `JSONEncoder`, which
+    /// would silently destroy user comments however they were smuggled in.
+    /// Full examples stay canonical in the docs page.
+    ///
+    /// Note: snippets only require `bundleId`, `appName`, and `context` —
+    /// `id` and `enabled` are optional in the file. See
+    /// `ContextSnippet.init(from:)` for the custom decoder.
+    private func seedStarterFileIfMissing() {
         guard !FileManager.default.fileExists(atPath: configFileURL.path) else { return }
         try? FileManager.default.createDirectory(at: configDirectory, withIntermediateDirectories: true)
-        let empty = """
+        let starter = """
         {
           "version": 1,
-          "snippets": []
+          "_docs": "https://getcai.app/docs/usage/context-snippets/",
+          "snippets": [
+            {
+              "bundleId": "com.apple.Terminal",
+              "appName": "Terminal",
+              "context": "When I copy from Terminal, I am usually debugging. Prefer technical, concise answers.",
+              "enabled": false
+            }
+          ]
         }
 
         """
-        try? empty.write(to: configFileURL, atomically: true, encoding: .utf8)
+        try? starter.write(to: configFileURL, atomically: true, encoding: .utf8)
     }
 
     /// Captures a load-failure message to be shown the next time Cai is invoked.

--- a/Cai/Cai/Views/SettingsView.swift
+++ b/Cai/Cai/Views/SettingsView.swift
@@ -354,9 +354,9 @@ struct SettingsView: View {
                         settingsDivider
 
                         // Context Snippets — per-app context (JSON-only in v1, UI coming in v1.1)
-                        settingsSection(title: "Context Snippets", badge: "ALPHA") {
+                        settingsSection(title: "Context Snippets") {
                             VStack(alignment: .leading, spacing: 8) {
-                                Text("Give Cai custom per-app context.\nExamples: 'Terminal: Rails debug logs' | 'GitHub: BUG:/FEAT: prefixes' | 'Slack: keep professional tone'.")
+                                Text("Give Cai custom per-app context. The snippets file starts with an example to copy.")
                                     .font(.system(size: 11))
                                     .foregroundColor(.caiTextSecondary)
                                     .fixedSize(horizontal: false, vertical: true)
@@ -372,7 +372,7 @@ struct SettingsView: View {
                                     }
                                     .buttonStyle(.plain)
                                     .accessibilityLabel("Open snippets.json in Finder")
-                                    .help("Open ~/.config/cai/snippets.json in Finder. Edit the file in your preferred editor, then restart Cai.")
+                                    .help("Open ~/.config/cai/snippets.json in Finder. Edit the file in your preferred editor. Changes apply automatically.")
 
                                     Text("·")
                                         .font(.system(size: 11))
@@ -780,8 +780,9 @@ struct SettingsView: View {
     // MARK: - Context Snippets Helpers
 
     /// Opens `~/.config/cai/snippets.json` in Finder with the file highlighted.
-    /// Creates the file first via `ContextSnippetsManager.shared` (which seeds an
-    /// empty template if missing) so the user always sees something to click.
+    /// Creates the file first via `ContextSnippetsManager.shared` (which seeds a
+    /// starter file with a disabled example if missing) so the user always sees
+    /// something to click and a shape to copy.
     private func openSnippetsFileInFinder() {
         // Touch the shared manager to ensure the file exists (seeds on first access)
         _ = ContextSnippetsManager.shared

--- a/Cai/CaiTests/ContextSnippetsTests.swift
+++ b/Cai/CaiTests/ContextSnippetsTests.swift
@@ -218,7 +218,7 @@ final class ContextSnippetsTests: XCTestCase {
         try? FileManager.default.removeItem(at: url)
     }
 
-    func testManagerLoadMissingFileSeedsEmptyAndReturnsEmptyList() {
+    func testManagerSeedsStarterFileWithDisabledExample() {
         let dir = makeTempDir()
         defer { cleanupTempDir(dir) }
 
@@ -228,16 +228,23 @@ final class ContextSnippetsTests: XCTestCase {
 
         let manager = ContextSnippetsManager(configDirectory: dir)
 
-        // Empty snippets
-        XCTAssertTrue(manager.snippets.isEmpty)
-        // Seed file was created
+        // Seed file was created and decodes as a valid v1 envelope
         XCTAssertTrue(FileManager.default.fileExists(atPath: fileURL.path))
-
-        // Seed file contains a valid empty envelope
         let data = try! Data(contentsOf: fileURL)
         let decoded = try! JSONDecoder().decode(ContextSnippetsFile.self, from: data)
         XCTAssertEqual(decoded.version, 1)
-        XCTAssertTrue(decoded.snippets.isEmpty)
+
+        // The starter example is present but disabled — seeding never changes behavior
+        XCTAssertEqual(decoded.snippets.count, 1)
+        XCTAssertFalse(decoded.snippets[0].enabled)
+        XCTAssertEqual(manager.snippets.count, 1)
+        XCTAssertNil(manager.snippet(forBundleId: decoded.snippets[0].bundleId),
+                     "Disabled starter example must be inert for lookups")
+
+        // The self-documentation link rides along as an ignored unknown key
+        let raw = String(data: data, encoding: .utf8)!
+        XCTAssertTrue(raw.contains("\"_docs\""),
+                      "Starter file should carry a _docs pointer to the manual")
     }
 
     func testManagerLoadEmptyFileReturnsEmptyList() throws {
@@ -342,6 +349,38 @@ final class ContextSnippetsTests: XCTestCase {
         let reloaded = try String(contentsOf: fileURL, encoding: .utf8)
         XCTAssertTrue(reloaded.contains("com.example.MyApp"))
         XCTAssertTrue(reloaded.contains("user content"))
+    }
+
+    // MARK: - Manager: Live Reload
+
+    @MainActor
+    func testWatcherReloadsSnippetsOnFileChange() throws {
+        let dir = makeTempDir()
+        defer { cleanupTempDir(dir) }
+
+        let manager = ContextSnippetsManager(configDirectory: dir)
+        manager.startWatching()
+        XCTAssertNil(manager.snippet(forBundleId: "com.example.Live"))
+
+        let updated = """
+        {
+          "version": 1,
+          "snippets": [
+            { "bundleId": "com.example.Live", "appName": "Live", "context": "hot reload" }
+          ]
+        }
+        """
+        try updated.write(to: dir.appendingPathComponent("snippets.json"),
+                          atomically: true, encoding: .utf8)
+
+        // The watcher debounces on the main queue (0.25s); pump the runloop
+        // until the reload lands or the generous cap expires.
+        let deadline = Date().addingTimeInterval(3)
+        while manager.snippet(forBundleId: "com.example.Live") == nil && Date() < deadline {
+            RunLoop.current.run(until: Date().addingTimeInterval(0.05))
+        }
+        XCTAssertNotNil(manager.snippet(forBundleId: "com.example.Live"),
+                        "Editing snippets.json should apply without restarting Cai")
     }
 
     // MARK: - Manager: Matching Logic


### PR DESCRIPTION
Opening `~/.config/cai/snippets.json` used to show an empty array, a dead end unless you found the docs, and edits only applied after restarting Cai. This makes the file teach itself, applies edits live, and retires the ALPHA badge now that the feature has been stable for months.

- Seed a starter file on first run: a `_docs` link plus one disabled Terminal example, so the schema is copyable in place. The example ships `enabled: false`, so seeding never changes behavior. Existing files are never touched.
- Live reload: a directory watcher (reusing `PendingChangeWatcher`) reloads snippets on save. Watching the directory instead of the file survives editors that save via temp-file-plus-rename. Malformed edits keep the existing toast behavior.
- Settings: ALPHA badge removed, caption simplified, tooltip now says changes apply automatically.
- No JSON comments by design: the planned v1.1 editor UI will rewrite the file through JSONEncoder and would destroy them. Docs stay the canonical home for full examples.

Tests: new coverage for the seed shape (example present, disabled, inert for lookups, `_docs` key survives parsing) and the live reload path. Full suite: 460 passed, 0 failed.