### PR TITLE
feat: put both directions of MCP behind one Settings row

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -30,7 +30,7 @@ Cai/Cai/
 ├── AppDelegate.swift         # Menu bar, hotkey, popover, lifecycle
 ├── Models/                   # ActionItem, CaiSettings, CaiShortcut, OutputDestination, BuiltInDestinations, MCPModels
 ├── Services/                 # Window/Clipboard/ContentDetector, LLMService + MLXInference, OutputDestinationService, MCP*, KeychainHelper, ClipboardHistory, OCRService, ExtensionParser/Service, HotKeyManager, PermissionsManager, UpdateChecker, CrashReportingService, PendingChangeStore/Watcher + ActionHistoryLog (agent proposals)
-└── Views/                    # ActionListWindow (router), ActionRow, ResultView, CustomPromptView, SettingsView, ShortcutsManagementView, DestinationsManagementView, ExtensionBrowserView, MCPFormView, ConnectorsSettingsView, ModelSetupView, OnboardingPermissionView, ToastWindow, ShortcutRecorderView, ActionReviewView (approval sheet), CaiColors, CaiLogo, KeyboardHint, AboutView, VisualEffectBackground
+└── Views/                    # ActionListWindow (router), ActionRow, ResultView, CustomPromptView, SettingsView, ShortcutsManagementView, DestinationsManagementView, ExtensionBrowserView, MCPFormView, MCPManagementView (Client/Server tabs), ConnectorsSettingsView, ConnectAgentContent + AgentConnection (connect-agent payloads), ModelSetupView, OnboardingPermissionView, ToastWindow, ShortcutRecorderView, ActionReviewView (approval sheet), CaiColors, CaiLogo, KeyboardHint, AboutView, VisualEffectBackground
 
 Cai/CaiActionCore/            # SPM package: authored-action schema, validator, approval tiers. Shared with the cai-mcp helper; every function pure and table-tested.
 ```

--- a/Cai/Cai/Services/MCPServerConfigManager.swift
+++ b/Cai/Cai/Services/MCPServerConfigManager.swift
@@ -73,6 +73,15 @@ class MCPServerConfigManager: ObservableObject {
         }.count
     }
 
+    /// Call after writing or removing a credential in Keychain. The Keychain
+    /// is not observable, so views deriving state from it (`configuredCount`
+    /// on the MCP screen's Client badge and the Settings row) only re-read
+    /// when this object publishes; without the nudge the badge sits one inch
+    /// above the save button showing the old count.
+    func credentialsDidChange() {
+        objectWillChange.send()
+    }
+
     /// Checks if a server has its API key configured in Keychain.
     func isServerConfigured(_ serverConfigId: UUID) -> Bool {
         guard let config = serverConfigs.first(where: { $0.id == serverConfigId }) else { return false }

--- a/Cai/Cai/Services/MCPServerConfigManager.swift
+++ b/Cai/Cai/Services/MCPServerConfigManager.swift
@@ -62,6 +62,17 @@ class MCPServerConfigManager: ObservableObject {
 
     // MARK: - Auth Check
 
+    /// Enabled servers whose credentials are actually present. The Settings
+    /// "N of M" row and the MCP screen's Client tab both show this number, so
+    /// it lives here rather than being computed separately by each view.
+    var configuredCount: Int {
+        serverConfigs.filter { config in
+            guard config.isEnabled else { return false }
+            guard let key = config.authKeychainKey else { return config.authType == .none }
+            return KeychainHelper.get(forKey: key) != nil
+        }.count
+    }
+
     /// Checks if a server has its API key configured in Keychain.
     func isServerConfigured(_ serverConfigId: UUID) -> Bool {
         guard let config = serverConfigs.first(where: { $0.id == serverConfigId }) else { return false }

--- a/Cai/Cai/Views/ActionListWindow.swift
+++ b/Cai/Cai/Views/ActionListWindow.swift
@@ -53,6 +53,10 @@ struct ActionListWindow: View {
     @State private var showDestinationsManagement: Bool = false
     @State private var showExtensionBrowser: Bool = false
     @State private var showConnectors: Bool = false
+    /// Which tab the MCP screen opens on. Settings opens Server (the release
+    /// headline); the missing-credentials redirect opens Client, because that
+    /// user was sent here to enter an API key.
+    @State private var connectorsInitialTab: MCPManagementView.Tab = .server
     @StateObject private var historySelectionState = SelectionState()
     @StateObject private var customPromptState = CustomPromptState()
     @ObservedObject private var settings = CaiSettings.shared
@@ -708,6 +712,7 @@ struct ActionListWindow: View {
                     }
                 },
                 onShowConnectors: {
+                    connectorsInitialTab = .server
                     withAnimation(.easeInOut(duration: 0.15)) {
                         showSettings = false
                         showConnectors = true
@@ -1389,9 +1394,11 @@ struct ActionListWindow: View {
 
         case .mcpAction(let configId):
             if let config = MCPActionConfigRegistry.shared.availableActions.first(where: { $0.id == configId }) {
-                // If API key not configured, redirect to Connectors setup
+                // If API key not configured, redirect to the MCP screen's
+                // Client tab, where the API-key form lives.
                 if !MCPServerConfigManager.shared.isServerConfigured(config.serverConfigId) {
                     selectionState.filterText = ""
+                    connectorsInitialTab = .client
                     withAnimation(.easeInOut(duration: 0.15)) {
                         showConnectors = true
                     }
@@ -1524,7 +1531,8 @@ struct ActionListWindow: View {
                         showConnectors = false
                         showSettings = true
                     }
-                }
+                },
+                initialTab: connectorsInitialTab
             )
         } else if showShortcutsManagement {
             ActionsManagementView(

--- a/Cai/Cai/Views/ActionListWindow.swift
+++ b/Cai/Cai/Views/ActionListWindow.swift
@@ -1518,7 +1518,7 @@ struct ActionListWindow: View {
                 }
             )
         } else if showConnectors {
-            ConnectorsSettingsView(
+            MCPManagementView(
                 onBack: {
                     withAnimation(.easeInOut(duration: 0.15)) {
                         showConnectors = false

--- a/Cai/Cai/Views/ActionReviewPresentation.swift
+++ b/Cai/Cai/Views/ActionReviewPresentation.swift
@@ -37,6 +37,8 @@ enum ActionReviewPresentation {
             return "This action replaces your selected text without showing a preview."
         case .runsWithoutShowingOutput:
             return "This action runs without showing its output."
+        case .chainsToUnknownAction:
+            return "This action triggers another action that doesn't exist yet, so Cai can't say what it will do."
         }
     }
 
@@ -57,6 +59,8 @@ enum ActionReviewPresentation {
             return "Replace your selected text without showing a preview"
         case .runsWithoutShowingOutput:
             return "Run without showing its output"
+        case .chainsToUnknownAction:
+            return "Trigger another action that doesn't exist yet"
         }
     }
 

--- a/Cai/Cai/Views/ActionReviewPresentation.swift
+++ b/Cai/Cai/Views/ActionReviewPresentation.swift
@@ -121,6 +121,16 @@ enum ActionReviewPresentation {
         return "\(index + 1) of \(total)"
     }
 
+    /// Keeps a browse position inside the queue as it changes underneath.
+    ///
+    /// The queue is live: a proposal can arrive or be withdrawn while the user
+    /// is reading one. Without clamping, deciding the last of three leaves the
+    /// index past the end and the sheet renders nothing at all.
+    static func clampedQueueIndex(_ index: Int, count: Int) -> Int {
+        guard count > 0 else { return 0 }
+        return min(max(0, index), count - 1)
+    }
+
     // MARK: - Toasts
 
     /// Arrival is passive: one toast, no window, no focus steal.

--- a/Cai/Cai/Views/ActionReviewPresentation.swift
+++ b/Cai/Cai/Views/ActionReviewPresentation.swift
@@ -80,35 +80,43 @@ enum ActionReviewPresentation {
         }
     }
 
-    /// The per-type acknowledgment that gates Approve. Deliberately the same
-    /// claim as the callout in the first person: the habituation defense only
-    /// works if checking the box means reading the sentence.
-    static func acknowledgment(for reason: EscalationReason) -> String {
-        switch reason {
-        case .runsShellCommands:
-            return "I understand this action can run terminal commands"
-        case .sendsSelectionToURL:
-            return "I understand this action sends my selected text to the URL shown above"
-        case .replacesSelection:
-            return "I understand this action replaces my selected text without showing a preview"
-        case .runsWithoutShowingOutput:
-            return "I understand this action runs without showing its output"
-        }
-    }
-
     // MARK: - The approve interlock
 
-    /// Whether Approve can fire. On the escalated tier every reason shown must
-    /// be acknowledged first, which is also what makes Return inert until the
-    /// boxes are checked: the button owns the shortcut, so a disabled button
-    /// swallows the key.
-    static func canApprove(
-        tier: ApprovalTier,
-        reasons: [EscalationReason],
-        acknowledged: Set<EscalationReason>
-    ) -> Bool {
-        guard tier == .escalated else { return true }
-        return reasons.allSatisfy { acknowledged.contains($0) }
+    /// One acknowledgment, however many risks the action carries.
+    ///
+    /// It used to be one checkbox per risk, which is where habituation actually
+    /// comes from: tick-tick-approve becomes muscle memory faster than a single
+    /// deliberate act does, and then the interlock is theatre. It also
+    /// contradicted the merged callout, which states every risk once.
+    ///
+    /// Not zero, though. This approval is permanent: the action runs from ⌥C
+    /// forever afterwards with no further prompt, unlike a per-invocation
+    /// permission that expires. Permanence is what buys one extra deliberate
+    /// act beyond the button the user was going to click anyway.
+    ///
+    /// This is also what makes Return inert until the box is ticked: Approve
+    /// owns the shortcut, and a disabled button swallows the key.
+    static func canApprove(tier: ApprovalTier, acknowledged: Bool) -> Bool {
+        tier == .escalated ? acknowledged : true
+    }
+
+    /// The label for that one checkbox.
+    ///
+    /// It refers to the callout rather than restating it. The design spec had a
+    /// per-risk sentence in the first person, which put the same words on
+    /// screen twice: "This action can run terminal commands on your Mac."
+    /// immediately above "I understand this action can run terminal commands".
+    /// Repetition on a small sheet costs height and teaches the eye to skip the
+    /// second copy, which works against the reading the checkbox exists to
+    /// force.
+    ///
+    /// Generic wording is only a problem when the label is the sole statement
+    /// of risk. It never is: this returns nil unless there are risks, and risks
+    /// always render the callout directly above.
+    static let acknowledgmentLabel = "I understand what this action can do"
+
+    static func acknowledgment(for reasons: [EscalationReason]) -> String? {
+        reasons.isEmpty ? nil : acknowledgmentLabel
     }
 
     // MARK: - Queue

--- a/Cai/Cai/Views/ActionReviewView.swift
+++ b/Cai/Cai/Views/ActionReviewView.swift
@@ -32,7 +32,9 @@ struct ActionReviewView: View {
     @State private var isArmed = false
 
     /// Which proposal is on screen. Browsing is allowed; deciding is still one
-    /// at a time, and every card keeps its own acknowledgments.
+    /// at a time. The acknowledgment is deliberately NOT kept per card: it is
+    /// dropped on every card change, browsing away and back included, because
+    /// a tick belongs to the payload that was on screen when it was made.
     @State private var browseIndex = 0
 
     private var proposal: PendingProposal? {
@@ -76,7 +78,10 @@ struct ActionReviewView: View {
         }
         .task(id: proposal) {
             isArmed = false
-            try? await Task.sleep(nanoseconds: 350_000_000)
+            // A cancelled sleep throws immediately. Arming anyway would hand
+            // the card that replaced this one an instantly live Approve, and
+            // stepping the queue cancels this task on every arrow press.
+            guard (try? await Task.sleep(nanoseconds: 350_000_000)) != nil else { return }
             isArmed = true
         }
     }

--- a/Cai/Cai/Views/ActionReviewView.swift
+++ b/Cai/Cai/Views/ActionReviewView.swift
@@ -20,10 +20,10 @@ struct ActionReviewView: View {
     let onClose: () -> Void
     let onOpenSettings: () -> Void
 
-    /// Reasons the user has ticked for the proposal on screen. Cleared whenever
-    /// the queue advances so the next proposal starts from zero: an
-    /// acknowledgment is about one payload, never inherited by the next.
-    @State private var acknowledged: Set<EscalationReason> = []
+    /// Whether the user has acknowledged what the proposal on screen can do.
+    /// Cleared whenever the card changes, so an acknowledgment is about one
+    /// payload and is never inherited by the next.
+    @State private var acknowledged = false
 
     /// False for a moment after the card changes. Approve owns the Return key
     /// and the queue advances in place, so without this a held or double
@@ -56,7 +56,7 @@ struct ActionReviewView: View {
         // Keyed on the whole proposal, not its id: a writer can rewrite the
         // same file in place, keeping the id while the payload changes. Ticks
         // belong to the bytes the user read, not to a filename.
-        .onChange(of: proposal) { _ in acknowledged = [] }
+        .onChange(of: proposal) { _ in acknowledged = false }
         .onChange(of: store.pending.count) { count in
             browseIndex = ActionReviewPresentation.clampedQueueIndex(browseIndex, count: count)
         }
@@ -175,8 +175,8 @@ struct ActionReviewView: View {
                 warnings(validated.warnings)
             }
 
-            if validated.tier == .escalated {
-                acknowledgments(for: validated.escalationReasons)
+            if let label = ActionReviewPresentation.acknowledgment(for: validated.escalationReasons) {
+                acknowledgmentRow(label)
             }
         }
         .padding(.horizontal, 16)
@@ -386,7 +386,7 @@ struct ActionReviewView: View {
             .truncationMode(.middle)
 
             HStack(spacing: 16) {
-                Text("Name: \(proposal.validated.after.name)")
+                Text("Action name: \(proposal.validated.after.name)")
                     .font(.system(size: 12))
                     .foregroundColor(.caiTextPrimary)
                     .lineLimit(1)
@@ -413,24 +413,16 @@ struct ActionReviewView: View {
         }
     }
 
-    /// The habituation defense. One box per risk, all of them required.
-    private func acknowledgments(for reasons: [EscalationReason]) -> some View {
-        VStack(alignment: .leading, spacing: 6) {
-            ForEach(reasons, id: \.self) { reason in
-                Toggle(isOn: Binding(
-                    get: { acknowledged.contains(reason) },
-                    set: { isOn in
-                        if isOn { acknowledged.insert(reason) } else { acknowledged.remove(reason) }
-                    }
-                )) {
-                    Text(ActionReviewPresentation.acknowledgment(for: reason))
-                        .font(.system(size: 12))
-                        .foregroundColor(.caiTextPrimary)
-                        .fixedSize(horizontal: false, vertical: true)
-                }
-                .toggleStyle(.checkbox)
-            }
+    /// The habituation defense: one deliberate act, not one per risk. See
+    /// `ActionReviewPresentation.canApprove` for why it is one and not zero.
+    private func acknowledgmentRow(_ label: String) -> some View {
+        Toggle(isOn: $acknowledged) {
+            Text(label)
+                .font(.system(size: 12))
+                .foregroundColor(.caiTextPrimary)
+                .fixedSize(horizontal: false, vertical: true)
         }
+        .toggleStyle(.checkbox)
     }
 
     // MARK: - Footer
@@ -438,7 +430,6 @@ struct ActionReviewView: View {
     private func footer(for proposal: PendingProposal) -> some View {
         let canApprove = isArmed && ActionReviewPresentation.canApprove(
             tier: proposal.validated.tier,
-            reasons: proposal.validated.escalationReasons,
             acknowledged: acknowledged
         )
 
@@ -480,7 +471,15 @@ struct ActionReviewView: View {
     private func approve(_ proposal: PendingProposal) {
         let isUpdate = proposal.validated.isUpdate
 
-        switch store.approve(proposal, acknowledged: acknowledged) {
+        // The store is handed the risks that were on screen, not a bare flag.
+        // It re-validates at this moment, and if a new risk appeared since the
+        // card was drawn it must not be covered by a tick the user gave to the
+        // old set (CAI-25).
+        let acknowledgedReasons: Set<EscalationReason> = acknowledged
+            ? Set(proposal.validated.escalationReasons)
+            : []
+
+        switch store.approve(proposal, acknowledged: acknowledgedReasons) {
         case .approved:
             NotificationCenter.default.post(
                 name: .caiShowToast,
@@ -496,9 +495,9 @@ struct ActionReviewView: View {
 
         case .needsAcknowledgment:
             // The action grew a risk since this card was drawn. The store has
-            // replaced the verdict, so the sheet is about to show callouts the
-            // user has not read: drop the ticks they made against the old one.
-            acknowledged = []
+            // replaced the verdict, so the sheet is about to show a claim the
+            // user has not read: drop the tick they gave the old one.
+            acknowledged = false
 
         case .stale:
             // The click landed on a card that already left the queue. Nothing

--- a/Cai/Cai/Views/ActionReviewView.swift
+++ b/Cai/Cai/Views/ActionReviewView.swift
@@ -31,7 +31,14 @@ struct ActionReviewView: View {
     /// arriving under the cursor can catch a click meant for the last one.
     @State private var isArmed = false
 
-    private var proposal: PendingProposal? { store.pending.first }
+    /// Which proposal is on screen. Browsing is allowed; deciding is still one
+    /// at a time, and every card keeps its own acknowledgments.
+    @State private var browseIndex = 0
+
+    private var proposal: PendingProposal? {
+        guard !store.pending.isEmpty else { return nil }
+        return store.pending[ActionReviewPresentation.clampedQueueIndex(browseIndex, count: store.pending.count)]
+    }
 
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
@@ -50,6 +57,23 @@ struct ActionReviewView: View {
         // same file in place, keeping the id while the payload changes. Ticks
         // belong to the bytes the user read, not to a filename.
         .onChange(of: proposal) { _ in acknowledged = [] }
+        .onChange(of: store.pending.count) { count in
+            browseIndex = ActionReviewPresentation.clampedQueueIndex(browseIndex, count: count)
+        }
+        // Left and right step the queue. Return and Esc are taken by Approve
+        // and defer, and the arrows are the macOS convention for moving
+        // through a set of items anyway.
+        .background {
+            VStack {
+                Button("") { if canGoBack { browseIndex -= 1 } }
+                    .keyboardShortcut(.leftArrow, modifiers: [])
+                Button("") { if canGoForward { browseIndex += 1 } }
+                    .keyboardShortcut(.rightArrow, modifiers: [])
+            }
+            .opacity(0)
+            .frame(width: 0, height: 0)
+            .accessibilityHidden(true)
+        }
         .task(id: proposal) {
             isArmed = false
             try? await Task.sleep(nanoseconds: 350_000_000)
@@ -67,20 +91,57 @@ struct ActionReviewView: View {
 
             Spacer()
 
-            if let counter = ActionReviewPresentation.queueCounter(index: 0, total: store.pending.count) {
-                Text(counter)
-                    .font(.system(size: 9, weight: .medium, design: .rounded))
-                    .monospacedDigit()
-                    .foregroundColor(.caiTextSecondary)
-                    .padding(.horizontal, 6)
-                    .padding(.vertical, 2)
-                    .background(RoundedRectangle(cornerRadius: 4).fill(Color.caiSurface.opacity(0.6)))
-                    .accessibilityLabel("Proposal \(counter)")
+            if let counter = ActionReviewPresentation.queueCounter(
+                index: browseIndex, total: store.pending.count
+            ) {
+                HStack(spacing: 2) {
+                    queueStepButton(systemName: "chevron.left", enabled: canGoBack, help: "Previous proposal") {
+                        browseIndex -= 1
+                    }
+
+                    Text(counter)
+                        .font(.system(size: 9, weight: .medium, design: .rounded))
+                        .monospacedDigit()
+                        .foregroundColor(.caiTextSecondary)
+                        .padding(.horizontal, 4)
+                        .accessibilityLabel("Proposal \(counter)")
+
+                    queueStepButton(systemName: "chevron.right", enabled: canGoForward, help: "Next proposal") {
+                        browseIndex += 1
+                    }
+                }
+                .padding(.horizontal, 2)
+                .padding(.vertical, 2)
+                .background(RoundedRectangle(cornerRadius: 4).fill(Color.caiSurface.opacity(0.6)))
             }
         }
         .padding(.horizontal, 16)
         .padding(.top, 16)
         .padding(.bottom, 12)
+    }
+
+    private var canGoBack: Bool { browseIndex > 0 }
+    private var canGoForward: Bool { browseIndex < store.pending.count - 1 }
+
+    /// A chevron the size of the counter beside it. Disabled rather than hidden
+    /// at the ends, so the control does not change width as you step.
+    private func queueStepButton(
+        systemName: String,
+        enabled: Bool,
+        help: String,
+        action: @escaping () -> Void
+    ) -> some View {
+        Button(action: action) {
+            Image(systemName: systemName)
+                .font(.system(size: 9, weight: .semibold))
+                .foregroundColor(enabled ? .caiTextSecondary : .caiTextSecondary.opacity(0.25))
+                .frame(width: 14, height: 14)
+                .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .disabled(!enabled)
+        .help(help)
+        .accessibilityLabel(help)
     }
 
     // MARK: - Content

--- a/Cai/Cai/Views/AgentConnection.swift
+++ b/Cai/Cai/Views/AgentConnection.swift
@@ -102,17 +102,39 @@ enum AgentConnection {
             // would never load there; its own CLI writes the right format.
             return "codex mcp add cai -- \(shellHelperPath(home: home))"
         case .cursor, .other:
-            // Absolute path, unescaped: this is JSON, not a shell.
+            // Absolute path, unescaped by shell rules: this is JSON, not a
+            // shell. The value still goes through the JSON encoder, so a home
+            // path carrying a quote or backslash cannot produce a config that
+            // fails to parse.
             return """
                 {
                   "mcpServers": {
                     "cai": {
-                      "command": "\(helperPath(home: home))"
+                      "command": \(jsonStringLiteral(helperPath(home: home)))
                     }
                   }
                 }
                 """
         }
+    }
+
+    /// A JSON string literal, quotes included. JSONEncoder rather than manual
+    /// replacement, same convention as webhook templates: hand-escaping is how
+    /// a stray backslash slips through.
+    private static func jsonStringLiteral(_ value: String) -> String {
+        let encoder = JSONEncoder()
+        // The default output escapes every "/" as "\/", which is valid JSON
+        // but turns a readable path into line noise in the snippet.
+        encoder.outputFormatting = .withoutEscapingSlashes
+        guard
+            let data = try? encoder.encode([value]),
+            let array = String(data: data, encoding: .utf8)
+        else {
+            return "\"\(value)\""
+        }
+        // Encoded as a one-element array for a stable top-level form; the
+        // brackets around ["..."] come off to leave the bare literal.
+        return String(array.dropFirst().dropLast())
     }
 
     /// Cursor publishes an install deeplink, so for that one client the whole

--- a/Cai/Cai/Views/AgentConnection.swift
+++ b/Cai/Cai/Views/AgentConnection.swift
@@ -1,0 +1,128 @@
+import CaiActionCore
+import Foundation
+
+/// What to hand a user so their agent can reach Cai.
+///
+/// Three entries, not one per client. Claude Code takes a CLI command, Cursor
+/// has a one-click install deeplink, and everything else takes the same JSON
+/// object, so listing Claude Desktop separately was three tabs showing two
+/// things.
+///
+/// Getting any of it wrong is invisible: a config that never loads produces no
+/// error anywhere the user will look. Pure and table-tested for the same reason
+/// the approval copy is, a wrong path here is a feature that silently does not
+/// exist.
+///
+/// Every instruction names the **symlink**, never the app bundle. The bundle
+/// path breaks when Cai is moved, renamed, or replaced by an update, and the
+/// failure surfaces inside the user's agent as a missing tool rather than as
+/// anything Cai can explain.
+enum AgentClient: String, CaseIterable, Identifiable {
+    case claudeCode
+    case cursor
+    case other
+
+    var id: String { rawValue }
+
+    var label: String {
+        switch self {
+        case .claudeCode: return "Claude Code"
+        case .cursor: return "Cursor"
+        case .other: return "Other"
+        }
+    }
+
+    /// How the user applies it, in the fewest words that are still true.
+    var instruction: String {
+        switch self {
+        case .claudeCode:
+            return "Run this in your terminal."
+        case .cursor:
+            return "One click. Cursor opens and adds Cai for you."
+        case .other:
+            return "Paste into Claude Desktop, Codex, or any other MCP client, under mcpServers."
+        }
+    }
+}
+
+enum AgentConnection {
+
+    // MARK: - Copy
+
+    static let sectionTitle = "Connect your agent"
+    static let killSwitchTitle = "Allow agents to propose actions"
+    static let killSwitchCaption = "Proposed actions always wait for your approval here before they can run."
+    static let copyButtonTitle = "Copy"
+    static let copiedButtonTitle = "Copied"
+    static let cursorButtonTitle = "Add to Cursor"
+    /// Shown under the deeplink button. Cursor takes the one-click install, but
+    /// an older build or a locked-down setup may not, and a dead button with no
+    /// alternative is a dead end.
+    static let cursorFallbackCaption = "Or paste this into Cursor Settings, MCP:"
+    /// Shown in place of the command when the switch is off, so the section
+    /// explains itself rather than just dimming.
+    static let disabledCaption = "Turn this on to let an agent propose actions. Nothing it proposes can run until you approve it."
+
+    // MARK: - The path everything points at
+
+    /// The stable path, with `$HOME` written as `~` for a command line and in
+    /// full for a JSON file, since JSON config readers do not expand `~`.
+    static func helperPath(home: URL = FileManager.default.homeDirectoryForCurrentUser) -> String {
+        CaiSupportPaths.helperSymlink(in: home.appendingPathComponent("Library/Application Support/Cai")).path
+    }
+
+    /// Shell form: `~` and an escaped space, because the path contains one and
+    /// an unescaped "Application Support" silently truncates the argument.
+    static func shellHelperPath(home: URL = FileManager.default.homeDirectoryForCurrentUser) -> String {
+        let full = helperPath(home: home)
+        let abbreviated = full.replacingOccurrences(of: home.path, with: "~")
+        return abbreviated.replacingOccurrences(of: " ", with: "\\ ")
+    }
+
+    // MARK: - Per-client payload
+
+    /// The text the copy button puts on the clipboard.
+    static func snippet(
+        for client: AgentClient,
+        home: URL = FileManager.default.homeDirectoryForCurrentUser
+    ) -> String {
+        switch client {
+        case .claudeCode:
+            return "claude mcp add cai -- \(shellHelperPath(home: home))"
+        case .cursor, .other:
+            // Absolute path, unescaped: this is JSON, not a shell.
+            return """
+                {
+                  "mcpServers": {
+                    "cai": {
+                      "command": "\(helperPath(home: home))"
+                    }
+                  }
+                }
+                """
+        }
+    }
+
+    /// Cursor publishes an install deeplink, so for that one client the whole
+    /// thing really is one click. Base64 of the server's config object, per
+    /// their documented format.
+    ///
+    /// Deliberately NOT us writing their config file: a scheme they publish and
+    /// own cannot corrupt a file that also holds the user's other servers.
+    static func cursorInstallURL(
+        home: URL = FileManager.default.homeDirectoryForCurrentUser
+    ) -> URL? {
+        let config = ["command": helperPath(home: home)]
+        guard
+            let json = try? JSONSerialization.data(withJSONObject: config),
+            var components = URLComponents(string: "cursor://anysphere.cursor-deeplink/mcp/install")
+        else {
+            return nil
+        }
+        components.queryItems = [
+            URLQueryItem(name: "name", value: "cai"),
+            URLQueryItem(name: "config", value: json.base64EncodedString()),
+        ]
+        return components.url
+    }
+}

--- a/Cai/Cai/Views/AgentConnection.swift
+++ b/Cai/Cai/Views/AgentConnection.swift
@@ -3,10 +3,10 @@ import Foundation
 
 /// What to hand a user so their agent can reach Cai.
 ///
-/// Three entries, not one per client. Claude Code takes a CLI command, Cursor
-/// has a one-click install deeplink, and everything else takes the same JSON
-/// object, so listing Claude Desktop separately was three tabs showing two
-/// things.
+/// One entry per distinct payload, not one per client. Claude Code and Codex
+/// take CLI commands, Cursor has a one-click install deeplink, and everything
+/// else takes the same JSON object, so listing Claude Desktop separately was
+/// a tab showing byte-identical JSON to "Other".
 ///
 /// Getting any of it wrong is invisible: a config that never loads produces no
 /// error anywhere the user will look. Pure and table-tested for the same reason
@@ -20,6 +20,7 @@ import Foundation
 enum AgentClient: String, CaseIterable, Identifiable {
     case claudeCode
     case cursor
+    case codex
     case other
 
     var id: String { rawValue }
@@ -28,6 +29,7 @@ enum AgentClient: String, CaseIterable, Identifiable {
         switch self {
         case .claudeCode: return "Claude Code"
         case .cursor: return "Cursor"
+        case .codex: return "Codex"
         case .other: return "Other"
         }
     }
@@ -35,12 +37,12 @@ enum AgentClient: String, CaseIterable, Identifiable {
     /// How the user applies it, in the fewest words that are still true.
     var instruction: String {
         switch self {
-        case .claudeCode:
+        case .claudeCode, .codex:
             return "Run this in your terminal."
         case .cursor:
             return "One click. Cursor opens and adds Cai for you."
         case .other:
-            return "Paste into Claude Desktop, Codex, or any other MCP client, under mcpServers."
+            return "Merge into your MCP client's JSON config, such as Claude Desktop's claude_desktop_config.json."
         }
     }
 }
@@ -49,7 +51,6 @@ enum AgentConnection {
 
     // MARK: - Copy
 
-    static let sectionTitle = "Connect your agent"
     static let killSwitchTitle = "Allow agents to propose actions"
     static let killSwitchCaption = "Proposed actions always wait for your approval here before they can run."
     static let copyButtonTitle = "Copy"
@@ -62,6 +63,10 @@ enum AgentConnection {
     /// Shown in place of the command when the switch is off, so the section
     /// explains itself rather than just dimming.
     static let disabledCaption = "Turn this on to let an agent propose actions. Nothing it proposes can run until you approve it."
+    /// Shown in place of the snippet when the helper symlink is missing even
+    /// after a repair attempt: handing out a path that points at nothing would
+    /// fail invisibly inside the user's agent.
+    static let helperMissingCaption = "Cai could not install its connection helper. Relaunch Cai to try again, or reinstall it if this keeps happening."
 
     // MARK: - The path everything points at
 
@@ -88,7 +93,14 @@ enum AgentConnection {
     ) -> String {
         switch client {
         case .claudeCode:
-            return "claude mcp add cai -- \(shellHelperPath(home: home))"
+            // --scope user, because the default is local: without it the
+            // connection exists only in the directory the command was run
+            // from, and Cai is a system-wide app.
+            return "claude mcp add --scope user cai -- \(shellHelperPath(home: home))"
+        case .codex:
+            // Codex reads TOML from ~/.codex/config.toml, so the JSON payload
+            // would never load there; its own CLI writes the right format.
+            return "codex mcp add cai -- \(shellHelperPath(home: home))"
         case .cursor, .other:
             // Absolute path, unescaped: this is JSON, not a shell.
             return """
@@ -123,6 +135,13 @@ enum AgentConnection {
             URLQueryItem(name: "name", value: "cai"),
             URLQueryItem(name: "config", value: json.base64EncodedString()),
         ]
+        // URLComponents leaves "+" bare in queries, but a form-style decoder
+        // reads a bare "+" as a space and the base64 stops decoding. Only
+        // non-ASCII home paths can put one in this payload, and for them the
+        // button would fail with nothing to see. Cursor's own generators run
+        // the config through encodeURIComponent, which escapes it too.
+        components.percentEncodedQuery = components.percentEncodedQuery?
+            .replacingOccurrences(of: "+", with: "%2B")
         return components.url
     }
 }

--- a/Cai/Cai/Views/ConnectAgentContent.swift
+++ b/Cai/Cai/Views/ConnectAgentContent.swift
@@ -1,0 +1,138 @@
+import SwiftUI
+
+/// The Server half of MCP: agents that reach into Cai to propose actions.
+///
+/// Renders without chrome; `MCPManagementView` owns the header and footer.
+///
+/// The kill switch comes first because it is the promise everything below
+/// depends on. The rest of the screen is "paste this somewhere"; the switch is
+/// "and nothing it sends can run until you approve it".
+struct ConnectAgentContent: View {
+
+    @ObservedObject private var settings = CaiSettings.shared
+
+    @State private var selectedClient: AgentClient = .claudeCode
+    /// Set for a beat after copying, so the button confirms rather than leaving
+    /// the user wondering whether the click registered.
+    @State private var copied = false
+
+    var body: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: 12) {
+                killSwitchRow
+
+                if settings.allowAgentProposals {
+                    Picker("", selection: $selectedClient) {
+                        ForEach(AgentClient.allCases) { client in
+                            Text(client.label).tag(client)
+                        }
+                    }
+                    .pickerStyle(.segmented)
+                    .labelsHidden()
+                    .controlSize(.small)
+                    .accessibilityLabel("Agent to connect")
+
+                    Text(selectedClient.instruction)
+                        .font(.system(size: 11))
+                        .foregroundColor(.caiTextSecondary)
+                        .fixedSize(horizontal: false, vertical: true)
+
+                    // Cursor leads with the deeplink, because for that one
+                    // client the whole job really is one click. The JSON stays
+                    // underneath as the fallback for anyone whose Cursor does
+                    // not take the scheme.
+                    if selectedClient == .cursor, let installURL = AgentConnection.cursorInstallURL() {
+                        Button(AgentConnection.cursorButtonTitle) {
+                            NSWorkspace.shared.open(installURL)
+                        }
+                        .buttonStyle(.borderedProminent)
+                        .tint(.caiPrimary)
+                        .controlSize(.small)
+                        .help("Opens Cursor and adds Cai for you")
+
+                        Text(AgentConnection.cursorFallbackCaption)
+                            .font(.system(size: 10))
+                            .foregroundColor(.caiTextSecondary.opacity(0.7))
+                    }
+
+                    snippetField
+                } else {
+                    Text(AgentConnection.disabledCaption)
+                        .font(.system(size: 11))
+                        .foregroundColor(.caiTextSecondary.opacity(0.7))
+                        .fixedSize(horizontal: false, vertical: true)
+                }
+            }
+            .padding(16)
+        }
+    }
+
+    private var killSwitchRow: some View {
+        HStack {
+            VStack(alignment: .leading, spacing: 2) {
+                Text(AgentConnection.killSwitchTitle)
+                    .font(.system(size: 12, weight: .medium))
+                    .foregroundColor(.caiTextPrimary)
+                Text(AgentConnection.killSwitchCaption)
+                    .font(.system(size: 10))
+                    .foregroundColor(.caiTextSecondary.opacity(0.7))
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+
+            Spacer()
+
+            Toggle("", isOn: $settings.allowAgentProposals)
+                .toggleStyle(.switch)
+                .controlSize(.mini)
+                .tint(.caiPrimary)
+                .labelsHidden()
+                .accessibilityLabel(AgentConnection.killSwitchTitle)
+        }
+        .padding(.horizontal, 12)
+        .padding(.vertical, 10)
+        .background(RoundedRectangle(cornerRadius: 10).fill(Color.caiSurface.opacity(0.3)))
+    }
+
+    /// The command or config, with copy as the primary action: this is a value
+    /// to take elsewhere, so reading it is secondary to copying it.
+    private var snippetField: some View {
+        let snippet = AgentConnection.snippet(for: selectedClient)
+
+        return HStack(alignment: .top, spacing: 8) {
+            Text(snippet)
+                .font(.system(size: 11, design: .monospaced))
+                .foregroundColor(.caiTextPrimary)
+                .textSelection(.enabled)
+                .fixedSize(horizontal: false, vertical: true)
+                .frame(maxWidth: .infinity, alignment: .leading)
+
+            Button(copied ? AgentConnection.copiedButtonTitle : AgentConnection.copyButtonTitle) {
+                copy(snippet)
+            }
+            .font(.system(size: 10, weight: .medium))
+            .buttonStyle(.plain)
+            .foregroundColor(.caiPrimary)
+            // Sized for the longer of the two labels. Without this, "Copy"
+            // becoming "Copied" widens the button and shoves the snippet
+            // sideways for the second and a half it takes to change back.
+            .frame(width: 44, alignment: .trailing)
+            .accessibilityLabel("Copy the \(selectedClient.label) command")
+        }
+        .padding(10)
+        .background(RoundedRectangle(cornerRadius: 8).fill(Color.caiSurface.opacity(0.5)))
+    }
+
+    private func copy(_ snippet: String) {
+        // Through the serial queue like every other pasteboard write, so it
+        // cannot interleave with a paste-back snapshot and cost the user their
+        // clipboard (CAI-01).
+        PasteboardQueue.shared.write {
+            NSPasteboard.general.clearContents()
+            NSPasteboard.general.setString(snippet, forType: .string)
+        }
+        copied = true
+        DispatchQueue.main.asyncAfter(deadline: .now() + 1.5) {
+            copied = false
+        }
+    }
+}

--- a/Cai/Cai/Views/ConnectAgentContent.swift
+++ b/Cai/Cai/Views/ConnectAgentContent.swift
@@ -15,13 +15,19 @@ struct ConnectAgentContent: View {
     /// Set for a beat after copying, so the button confirms rather than leaving
     /// the user wondering whether the click registered.
     @State private var copied = false
+    /// True when the helper symlink is absent even after a repair attempt.
+    /// The snippet is withheld then: a copied path that points at nothing
+    /// fails invisibly inside the user's agent.
+    @State private var helperMissing = false
 
     var body: some View {
         ScrollView {
             VStack(alignment: .leading, spacing: 12) {
                 killSwitchRow
 
-                if settings.allowAgentProposals {
+                if settings.allowAgentProposals, helperMissing {
+                    helperMissingRow
+                } else if settings.allowAgentProposals {
                     Picker("", selection: $selectedClient) {
                         ForEach(AgentClient.allCases) { client in
                             Text(client.label).tag(client)
@@ -64,6 +70,30 @@ struct ConnectAgentContent: View {
                 }
             }
             .padding(16)
+        }
+        .onAppear(perform: verifyHelper)
+        .onChange(of: settings.allowAgentProposals) { enabled in
+            if enabled { verifyHelper() }
+        }
+    }
+
+    /// Repairs the symlink the way launch does, then checks whether the path
+    /// every snippet names actually resolves. `fileExists` follows symlinks,
+    /// so a dangling link counts as missing.
+    private func verifyHelper() {
+        HelperInstaller.refreshSymlink()
+        helperMissing = !FileManager.default.fileExists(atPath: AgentConnection.helperPath())
+    }
+
+    private var helperMissingRow: some View {
+        HStack(alignment: .top, spacing: 6) {
+            Image(systemName: "exclamationmark.triangle")
+                .font(.system(size: 11))
+                .foregroundColor(.caiTextSecondary)
+            Text(AgentConnection.helperMissingCaption)
+                .font(.system(size: 11))
+                .foregroundColor(.caiTextSecondary)
+                .fixedSize(horizontal: false, vertical: true)
         }
     }
 
@@ -129,10 +159,15 @@ struct ConnectAgentContent: View {
         PasteboardQueue.shared.write {
             NSPasteboard.general.clearContents()
             NSPasteboard.general.setString(snippet, forType: .string)
-        }
-        copied = true
-        DispatchQueue.main.asyncAfter(deadline: .now() + 1.5) {
-            copied = false
+            // Confirm from inside the queued block: if the queue is busy
+            // draining a paste-back, "Copied" must not show while the
+            // pasteboard still holds the old contents.
+            DispatchQueue.main.async {
+                copied = true
+                DispatchQueue.main.asyncAfter(deadline: .now() + 1.5) {
+                    copied = false
+                }
+            }
         }
     }
 }

--- a/Cai/Cai/Views/ConnectorsSettingsView.swift
+++ b/Cai/Cai/Views/ConnectorsSettingsView.swift
@@ -398,6 +398,9 @@ struct ConnectorsSettingsView: View {
         guard !trimmed.isEmpty else { return }
 
         KeychainHelper.set(trimmed, forKey: keychainKey)
+        // The Keychain is not observable: publish so the "N of M" counts
+        // (the MCP screen's Client badge, the Settings row) re-read it.
+        configManager.credentialsDidChange()
         // Clear the field after save — the "Key saved in Keychain" indicator below
         // confirms success. Leaving the raw token in the field is a minor privacy risk.
         apiKeyInputs[config.id] = ""

--- a/Cai/Cai/Views/ConnectorsSettingsView.swift
+++ b/Cai/Cai/Views/ConnectorsSettingsView.swift
@@ -2,10 +2,15 @@ import SwiftUI
 
 /// Settings sub-view for managing MCP server connections (GitHub, Linear, etc.).
 /// Shows configured servers with status indicators, API key entry, and test connection.
-/// Follows the same push-navigation pattern as DestinationsManagementView.
+///
+/// Embedded as the Client tab of `MCPManagementView`, which supplies the header
+/// and footer, so `showsChrome` suppresses its own (same convention as
+/// `ShortcutsManagementView` inside `ActionsManagementView`).
 struct ConnectorsSettingsView: View {
     @ObservedObject var configManager = MCPServerConfigManager.shared
     let onBack: () -> Void
+    /// False when a parent screen owns the chrome.
+    var showsChrome: Bool = true
 
     @State private var editingServerId: UUID?
     @State private var apiKeyInputs: [UUID: String] = [:]  // Temp input state per server
@@ -14,6 +19,7 @@ struct ConnectorsSettingsView: View {
 
     var body: some View {
         VStack(spacing: 0) {
+            if showsChrome {
             // Header
             HStack {
                 Text("Connectors")
@@ -29,6 +35,7 @@ struct ConnectorsSettingsView: View {
 
             Divider()
                 .background(Color.caiDivider)
+            }
 
             // Content
             ScrollView {
@@ -67,16 +74,18 @@ struct ConnectorsSettingsView: View {
 
             Spacer(minLength: 0)
 
-            Divider()
-                .background(Color.caiDivider)
+            if showsChrome {
+                Divider()
+                    .background(Color.caiDivider)
 
-            // Footer
-            HStack {
-                KeyboardHint(key: "Esc", label: "Back")
-                Spacer()
+                // Footer
+                HStack {
+                    KeyboardHint(key: "Esc", label: "Back")
+                    Spacer()
+                }
+                .padding(.horizontal, 16)
+                .padding(.vertical, 8)
             }
-            .padding(.horizontal, 16)
-            .padding(.vertical, 8)
         }
         .onAppear {
             WindowController.acceptsFilterInput = false

--- a/Cai/Cai/Views/MCPManagementView.swift
+++ b/Cai/Cai/Views/MCPManagementView.swift
@@ -33,7 +33,15 @@ struct MCPManagementView: View {
         case client, server
     }
 
-    @State private var selectedTab: Tab = .server
+    @State private var selectedTab: Tab
+
+    /// `initialTab` defaults to Server (the headline for this release), but
+    /// the missing-credentials redirect passes `.client`: a user sent here to
+    /// enter an API key must land on the form, not on agent setup.
+    init(onBack: @escaping () -> Void, initialTab: Tab = .server) {
+        self.onBack = onBack
+        _selectedTab = State(initialValue: initialTab)
+    }
 
     var body: some View {
         ManagementScreen(
@@ -42,7 +50,7 @@ struct MCPManagementView: View {
             subtitle: subtitle,
             tabs: [
                 .init(id: .server, label: "Server"),
-                .init(id: .client, label: "Client", count: configuredConnectors),
+                .init(id: .client, label: "Client", count: configManager.configuredCount),
             ],
             selection: $selectedTab,
             customTabId: nil,
@@ -64,15 +72,5 @@ struct MCPManagementView: View {
         case .server:
             return "Agents that can propose actions to Cai"
         }
-    }
-
-    /// Enabled connectors that actually have their credentials, matching what
-    /// the old Settings row counted.
-    private var configuredConnectors: Int {
-        configManager.serverConfigs.filter { config in
-            guard config.isEnabled else { return false }
-            guard let key = config.authKeychainKey else { return config.authType == .none }
-            return KeychainHelper.get(forKey: key) != nil
-        }.count
     }
 }

--- a/Cai/Cai/Views/MCPManagementView.swift
+++ b/Cai/Cai/Views/MCPManagementView.swift
@@ -1,0 +1,78 @@
+import SwiftUI
+
+/// Unified "MCP" screen: the two directions MCP runs in, under one parent.
+///
+/// **Client** is Cai reaching out to tools (GitHub, Linear): the existing
+/// Connectors screen. **Server** is an agent reaching into Cai to propose
+/// actions: the `cai-mcp` helper.
+///
+/// One row in Settings rather than two, because they are the same protocol and
+/// a user looking for "the MCP thing" should find one door. Tabs rather than
+/// nesting, because the directions must not blur: the design review's original
+/// instruction was to keep author and consume visually distinct, and a labelled
+/// tab does that better than a separate section did. See the deviations table in
+/// `_docs/planning/active/MCP-AUTHORING-MLP-PLAN.md`.
+///
+/// The tab labels are short jargon; the subtitle underneath does the explaining,
+/// which is how the header earns its keep on both tabs.
+///
+/// **Server leads, for now.** DESIGN.md gives the dominant slot to the
+/// most-edited tab, which taken literally would be Client: connectors hold
+/// credentials a user comes back to, while connecting an agent is a one-time
+/// job. It is second anyway, because the release that introduces this screen is
+/// headlined "create Cai actions from Claude Code" and nearly every visit for a
+/// while will be someone wiring an agent up. Revisit once authoring stops being
+/// the new thing; the cost today is that a Connectors user lands one click from
+/// where they used to arrive.
+struct MCPManagementView: View {
+
+    @ObservedObject private var configManager = MCPServerConfigManager.shared
+    let onBack: () -> Void
+
+    enum Tab: Hashable {
+        case client, server
+    }
+
+    @State private var selectedTab: Tab = .server
+
+    var body: some View {
+        ManagementScreen(
+            icon: "link",
+            title: "MCP",
+            subtitle: subtitle,
+            tabs: [
+                .init(id: .server, label: "Server"),
+                .init(id: .client, label: "Client", count: configuredConnectors),
+            ],
+            selection: $selectedTab,
+            customTabId: nil,
+            onAdd: nil
+        ) {
+            switch selectedTab {
+            case .client:
+                ConnectorsSettingsView(onBack: onBack, showsChrome: false)
+            case .server:
+                ConnectAgentContent()
+            }
+        }
+    }
+
+    private var subtitle: String {
+        switch selectedTab {
+        case .client:
+            return "Tools Cai can use, like GitHub or Linear"
+        case .server:
+            return "Agents that can propose actions to Cai"
+        }
+    }
+
+    /// Enabled connectors that actually have their credentials, matching what
+    /// the old Settings row counted.
+    private var configuredConnectors: Int {
+        configManager.serverConfigs.filter { config in
+            guard config.isEnabled else { return false }
+            guard let key = config.authKeychainKey else { return config.authType == .none }
+            return KeychainHelper.get(forKey: key) != nil
+        }.count
+    }
+}

--- a/Cai/Cai/Views/SettingsView.swift
+++ b/Cai/Cai/Views/SettingsView.swift
@@ -290,7 +290,7 @@ struct SettingsView: View {
 
                         settingsDivider
 
-                        connectorsNavRow
+                        mcpNavRow
                     }
 
                     Button(action: onShowExtensions ?? {}) {
@@ -868,7 +868,10 @@ struct SettingsView: View {
 
     @ObservedObject private var mcpConfigManager = MCPServerConfigManager.shared
 
-    private var connectorsNavRow: some View {
+    /// One row for both directions of MCP: tools Cai uses, and agents that
+    /// propose actions to it. The count stays the connector count, since that
+    /// is the only side with a meaningful "N of M configured".
+    private var mcpNavRow: some View {
         let configs = mcpConfigManager.serverConfigs
         let configured = configs.filter { config in
             guard config.isEnabled else { return false }
@@ -878,7 +881,7 @@ struct SettingsView: View {
         let total = configs.count
 
         return navRow(
-            label: "Connectors",
+            label: "MCP",
             count: configured,
             total: total,
             action: onShowConnectors

--- a/Cai/Cai/Views/SettingsView.swift
+++ b/Cai/Cai/Views/SettingsView.swift
@@ -872,18 +872,10 @@ struct SettingsView: View {
     /// propose actions to it. The count stays the connector count, since that
     /// is the only side with a meaningful "N of M configured".
     private var mcpNavRow: some View {
-        let configs = mcpConfigManager.serverConfigs
-        let configured = configs.filter { config in
-            guard config.isEnabled else { return false }
-            guard let key = config.authKeychainKey else { return config.authType == .none }
-            return KeychainHelper.get(forKey: key) != nil
-        }.count
-        let total = configs.count
-
-        return navRow(
+        navRow(
             label: "MCP",
-            count: configured,
-            total: total,
+            count: mcpConfigManager.configuredCount,
+            total: mcpConfigManager.serverConfigs.count,
             action: onShowConnectors
         )
     }

--- a/Cai/CaiActionCore/Sources/CaiActionCore/ApprovalTier.swift
+++ b/Cai/CaiActionCore/Sources/CaiActionCore/ApprovalTier.swift
@@ -5,8 +5,8 @@ public enum ApprovalTier: String, Codable, Equatable, Sendable {
     /// Prompt action, no flags, no executable chain: name, payload, approve.
     case standard
     /// Anything that can run code, reach the network, or change the user's
-    /// text without review. Warning styling plus a per-type acknowledgment
-    /// checkbox that gates the Approve button.
+    /// text without review. Warning styling plus an acknowledgment checkbox
+    /// that gates the Approve button.
     case escalated
 }
 
@@ -22,6 +22,13 @@ public enum EscalationReason: String, Codable, Equatable, Sendable, CaseIterable
     case replacesSelection
     /// `runInBackground`.
     case runsWithoutShowingOutput
+    /// A chain step naming an action that resolves to nothing. It runs
+    /// nothing today, but the name can be claimed by a later proposal: approve
+    /// this with one click, then approve a shell action carrying that name,
+    /// and this action reaches shell without its callout ever appearing. The
+    /// risk is the blind handoff, so it escalates now, while the user is
+    /// looking.
+    case chainsToUnknownAction
 }
 
 public enum ApprovalClassifier {
@@ -109,10 +116,16 @@ public enum ApprovalClassifier {
                         case .clipboardCopy:
                             continue
                         }
-                    case .builtIn, .unresolved:
-                        // Built-ins are leaf LLM transforms. An unresolved name
-                        // runs nothing at all; it surfaces as a warning instead.
+                    case .builtIn:
+                        // Built-ins are leaf LLM transforms.
                         continue
+                    case .unresolved:
+                        // Runs nothing today, but "today" is when the user is
+                        // deciding: a later proposal can claim the name and
+                        // this action starts reaching whatever it does. The
+                        // unresolved-step warning still names the steps; this
+                        // is what makes the approval a deliberate act.
+                        found.insert(.chainsToUnknownAction)
                     }
                 }
             }

--- a/Cai/CaiTests/ActionReviewPresentationTests.swift
+++ b/Cai/CaiTests/ActionReviewPresentationTests.swift
@@ -11,18 +11,11 @@ final class ActionReviewPresentationTests: XCTestCase {
 
     // MARK: - Escalation copy
 
-    func testEveryReasonHasACalloutAndAMatchingAcknowledgment() {
+    func testEveryReasonHasACallout() {
         for reason in EscalationReason.allCases {
             let callout = ActionReviewPresentation.callout(for: reason)
-            let acknowledgment = ActionReviewPresentation.acknowledgment(for: reason)
-
             XCTAssertFalse(callout.isEmpty, "\(reason) has no callout")
             XCTAssertTrue(callout.hasSuffix("."), "Callouts are sentences: \(callout)")
-            XCTAssertTrue(
-                acknowledgment.hasPrefix("I understand this action "),
-                "The acknowledgment must restate the claim in the first person: \(acknowledgment)"
-            )
-            XCTAssertFalse(acknowledgment.hasSuffix("."), "Checkbox labels are not sentences: \(acknowledgment)")
         }
     }
 
@@ -42,10 +35,6 @@ final class ActionReviewPresentationTests: XCTestCase {
         XCTAssertEqual(
             ActionReviewPresentation.callout(for: .runsWithoutShowingOutput),
             "This action runs without showing its output."
-        )
-        XCTAssertEqual(
-            ActionReviewPresentation.acknowledgment(for: .runsShellCommands),
-            "I understand this action can run terminal commands"
         )
     }
 
@@ -97,7 +86,7 @@ final class ActionReviewPresentationTests: XCTestCase {
             ActionReviewPresentation.approvedToast(isUpdate: true),
         ]
         strings += EscalationReason.allCases.map(ActionReviewPresentation.callout)
-        strings += EscalationReason.allCases.map(ActionReviewPresentation.acknowledgment)
+        strings.append(ActionReviewPresentation.acknowledgmentLabel)
         strings += ActionField.allCases.map(ActionReviewPresentation.fieldLabel)
 
         for string in strings {
@@ -107,65 +96,45 @@ final class ActionReviewPresentationTests: XCTestCase {
 
     // MARK: - The approve interlock
 
-    private struct InterlockCase {
-        let label: String
-        let tier: ApprovalTier
-        let reasons: [EscalationReason]
-        let acknowledged: Set<EscalationReason>
-        let expected: Bool
-        let line: UInt
+    func testApproveNeedsTheAcknowledgmentOnlyOnTheEscalatedTier() {
+        XCTAssertTrue(ActionReviewPresentation.canApprove(tier: .standard, acknowledged: false))
+        XCTAssertTrue(ActionReviewPresentation.canApprove(tier: .standard, acknowledged: true))
+        XCTAssertFalse(
+            ActionReviewPresentation.canApprove(tier: .escalated, acknowledged: false),
+            "An escalated proposal must not be approvable on one click."
+        )
+        XCTAssertTrue(ActionReviewPresentation.canApprove(tier: .escalated, acknowledged: true))
     }
 
-    func testApproveInterlockMatrix() {
-        let cases: [InterlockCase] = [
-            InterlockCase(
-                label: "standard tier needs no acknowledgment",
-                tier: .standard, reasons: [], acknowledged: [], expected: true, line: #line
-            ),
-            InterlockCase(
-                label: "escalated with nothing checked stays blocked",
-                tier: .escalated, reasons: [.runsShellCommands], acknowledged: [], expected: false, line: #line
-            ),
-            InterlockCase(
-                label: "escalated with its one box checked unblocks",
-                tier: .escalated, reasons: [.runsShellCommands], acknowledged: [.runsShellCommands],
-                expected: true, line: #line
-            ),
-            InterlockCase(
-                label: "two risks, one acknowledged, still blocked",
-                tier: .escalated,
-                reasons: [.runsShellCommands, .replacesSelection],
-                acknowledged: [.runsShellCommands],
-                expected: false, line: #line
-            ),
-            InterlockCase(
-                label: "two risks, both acknowledged",
-                tier: .escalated,
-                reasons: [.runsShellCommands, .replacesSelection],
-                acknowledged: [.runsShellCommands, .replacesSelection],
-                expected: true, line: #line
-            ),
-            InterlockCase(
-                label: "acknowledging a risk this action does not carry does not unblock it",
-                tier: .escalated,
-                reasons: [.runsShellCommands],
-                acknowledged: [.runsWithoutShowingOutput],
-                expected: false, line: #line
-            ),
-        ]
+    func testTheAcknowledgmentRefersToTheCalloutRatherThanRestatingIt() {
+        // "This action can run terminal commands on your Mac." directly above
+        // "I understand this action can run terminal commands" is the same
+        // sentence twice, which costs height and teaches the eye to skip it.
+        let label = ActionReviewPresentation.acknowledgment(for: [.runsShellCommands])
 
-        for testCase in cases {
-            XCTAssertEqual(
-                ActionReviewPresentation.canApprove(
-                    tier: testCase.tier,
-                    reasons: testCase.reasons,
-                    acknowledged: testCase.acknowledged
-                ),
-                testCase.expected,
-                testCase.label,
-                line: testCase.line
+        XCTAssertEqual(label, "I understand what this action can do")
+        XCTAssertFalse(
+            label?.contains("terminal") ?? true,
+            "The risk is stated in the callout; the checkbox points at it."
+        )
+    }
+
+    func testTheAcknowledgmentIsTheSameWhateverTheRisks() {
+        // One box, one wording. The callout carries the specifics, so the label
+        // does not grow a clause per risk.
+        XCTAssertEqual(
+            ActionReviewPresentation.acknowledgment(for: [.runsShellCommands]),
+            ActionReviewPresentation.acknowledgment(
+                for: [.runsShellCommands, .sendsSelectionToURL, .runsWithoutShowingOutput]
             )
-        }
+        )
+    }
+
+    func testNoRisksNeedNoAcknowledgment() {
+        XCTAssertNil(
+            ActionReviewPresentation.acknowledgment(for: []),
+            "No callout, so nothing for a checkbox to point at."
+        )
     }
 
     // MARK: - Queue counter

--- a/Cai/CaiTests/ActionReviewPresentationTests.swift
+++ b/Cai/CaiTests/ActionReviewPresentationTests.swift
@@ -36,6 +36,13 @@ final class ActionReviewPresentationTests: XCTestCase {
             ActionReviewPresentation.callout(for: .runsWithoutShowingOutput),
             "This action runs without showing its output."
         )
+        // Not in the design spec's original four: added when unresolved chain
+        // names started escalating, because a name no one has claimed yet can
+        // be claimed by a later shell action.
+        XCTAssertEqual(
+            ActionReviewPresentation.callout(for: .chainsToUnknownAction),
+            "This action triggers another action that doesn't exist yet, so Cai can't say what it will do."
+        )
     }
 
     // MARK: - Grouped callout

--- a/Cai/CaiTests/ActionReviewPresentationTests.swift
+++ b/Cai/CaiTests/ActionReviewPresentationTests.swift
@@ -177,6 +177,29 @@ final class ActionReviewPresentationTests: XCTestCase {
         XCTAssertEqual(ActionReviewPresentation.queueCounter(index: 2, total: 3), "3 of 3")
     }
 
+    // MARK: - Browsing the queue
+
+    func testTheBrowsePositionStaysInsideALiveQueue() {
+        // Deciding the last of three leaves the index past the end; unclamped,
+        // the sheet renders nothing at all.
+        XCTAssertEqual(ActionReviewPresentation.clampedQueueIndex(2, count: 2), 1)
+        XCTAssertEqual(ActionReviewPresentation.clampedQueueIndex(5, count: 3), 2)
+        XCTAssertEqual(ActionReviewPresentation.clampedQueueIndex(-1, count: 3), 0)
+        XCTAssertEqual(ActionReviewPresentation.clampedQueueIndex(1, count: 3), 1)
+    }
+
+    func testAnEmptyQueueClampsToZeroRatherThanCrashing() {
+        XCTAssertEqual(ActionReviewPresentation.clampedQueueIndex(4, count: 0), 0)
+    }
+
+    func testTheCounterFollowsTheBrowsePosition() {
+        XCTAssertEqual(ActionReviewPresentation.queueCounter(index: 1, total: 3), "2 of 3")
+        XCTAssertNil(
+            ActionReviewPresentation.queueCounter(index: 0, total: 1),
+            "One proposal needs no position indicator, and no chevrons to go with it."
+        )
+    }
+
     // MARK: - Toasts and provenance
 
     func testArrivalToastNamesTheClientAndFallsBackWhenItIsMissing() {

--- a/Cai/CaiTests/AgentConnectionTests.swift
+++ b/Cai/CaiTests/AgentConnectionTests.swift
@@ -91,6 +91,21 @@ final class AgentConnectionTests: XCTestCase {
         }
     }
 
+    func testTheJSONFormSurvivesAHomePathWithAQuoteOrBackslash() throws {
+        // A quote or backslash interpolated raw into the snippet is invalid
+        // JSON, and the config silently never loads in the user's client.
+        let home = URL(fileURLWithPath: "/Users/A\"User\\Odd")
+        let snippet = AgentConnection.snippet(for: .other, home: home)
+
+        let parsed = try JSONSerialization.jsonObject(with: Data(snippet.utf8)) as? [String: Any]
+        let servers = try XCTUnwrap(parsed?["mcpServers"] as? [String: Any])
+        let cai = try XCTUnwrap(servers["cai"] as? [String: Any])
+        XCTAssertEqual(
+            cai["command"] as? String,
+            "/Users/A\"User\\Odd/Library/Application Support/Cai/bin/cai-mcp"
+        )
+    }
+
     func testEveryClientSaysWhatToDoWithIt() {
         for client in AgentClient.allCases {
             XCTAssertFalse(client.instruction.isEmpty, client.label)

--- a/Cai/CaiTests/AgentConnectionTests.swift
+++ b/Cai/CaiTests/AgentConnectionTests.swift
@@ -1,0 +1,134 @@
+import CaiActionCore
+import XCTest
+@testable import Cai
+
+/// What Settings hands the user to wire their agent up.
+///
+/// Worth testing because the failure is invisible: a wrong path or a bad quote
+/// produces a config that never loads, and the user sees a missing tool inside
+/// their agent with nothing in Cai to explain it.
+final class AgentConnectionTests: XCTestCase {
+
+    private let home = URL(fileURLWithPath: "/Users/tester")
+
+    // MARK: - The path
+
+    func testEveryClientPointsAtTheSymlinkNotTheAppBundle() {
+        for client in AgentClient.allCases {
+            let snippet = AgentConnection.snippet(for: client, home: home)
+            XCTAssertTrue(
+                snippet.contains("Application Support/Cai/bin/cai-mcp")
+                    || snippet.contains("Application\\ Support/Cai/bin/cai-mcp"),
+                "\(client.label) must use the stable path, which survives Cai being moved or updated: \(snippet)"
+            )
+            XCTAssertFalse(
+                snippet.contains(".app/Contents"),
+                "\(client.label) points into the bundle, which breaks on the next update: \(snippet)"
+            )
+        }
+    }
+
+    func testTheShellFormAbbreviatesHomeAndEscapesTheSpace() {
+        let path = AgentConnection.shellHelperPath(home: home)
+
+        XCTAssertEqual(path, "~/Library/Application\\ Support/Cai/bin/cai-mcp")
+        XCTAssertFalse(
+            path.contains("Application Support"),
+            "An unescaped space truncates the argument and the command silently registers the wrong binary."
+        )
+    }
+
+    func testTheJSONFormUsesAnAbsoluteUnescapedPath() {
+        let snippet = AgentConnection.snippet(for: .other, home: home)
+
+        XCTAssertTrue(snippet.contains("/Users/tester/Library/Application Support/Cai/bin/cai-mcp"), snippet)
+        XCTAssertFalse(snippet.contains("~"), "JSON config readers do not expand a tilde.")
+        XCTAssertFalse(snippet.contains("\\ "), "A shell escape inside JSON is a broken path.")
+    }
+
+    // MARK: - Per-client shape
+
+    func testClaudeCodeGetsACommandToRun() {
+        XCTAssertEqual(
+            AgentConnection.snippet(for: .claudeCode, home: home),
+            "claude mcp add cai -- ~/Library/Application\\ Support/Cai/bin/cai-mcp"
+        )
+    }
+
+    func testThereIsOneTabPerDistinctThingToDo() {
+        // Claude Desktop used to have its own tab showing byte-identical JSON
+        // to "Other". Three tabs, two payloads.
+        XCTAssertEqual(AgentClient.allCases.count, 3)
+        XCTAssertEqual(
+            AgentConnection.snippet(for: .cursor, home: home),
+            AgentConnection.snippet(for: .other, home: home),
+            "If these ever diverge, Cursor needs its own snippet rather than sharing one."
+        )
+    }
+
+    func testTheOthersGetValidJSONUnderMcpServers() throws {
+        for client in [AgentClient.cursor, .other] {
+            let snippet = AgentConnection.snippet(for: client, home: home)
+            let parsed = try JSONSerialization.jsonObject(
+                with: Data(snippet.utf8)
+            ) as? [String: Any]
+
+            let servers = try XCTUnwrap(parsed?["mcpServers"] as? [String: Any], "\(client.label): no mcpServers")
+            let cai = try XCTUnwrap(servers["cai"] as? [String: Any], "\(client.label): no cai entry")
+            XCTAssertNotNil(cai["command"], "\(client.label): no command")
+        }
+    }
+
+    func testEveryClientSaysWhatToDoWithIt() {
+        for client in AgentClient.allCases {
+            XCTAssertFalse(client.instruction.isEmpty, client.label)
+            XCTAssertFalse(client.instruction.contains("—"), client.instruction)
+        }
+    }
+
+    // MARK: - Cursor deeplink
+
+    func testCursorDeeplinkCarriesTheConfigAsBase64() throws {
+        let url = try XCTUnwrap(AgentConnection.cursorInstallURL(home: home))
+        let components = try XCTUnwrap(URLComponents(url: url, resolvingAgainstBaseURL: false))
+
+        XCTAssertEqual(url.scheme, "cursor")
+        XCTAssertEqual(components.queryItems?.first { $0.name == "name" }?.value, "cai")
+
+        let encoded = try XCTUnwrap(components.queryItems?.first { $0.name == "config" }?.value)
+        let decoded = try XCTUnwrap(Data(base64Encoded: encoded))
+        let config = try XCTUnwrap(
+            try JSONSerialization.jsonObject(with: decoded) as? [String: String]
+        )
+
+        XCTAssertEqual(config["command"], "/Users/tester/Library/Application Support/Cai/bin/cai-mcp")
+    }
+
+    // MARK: - Copy
+
+    func testNoConnectCopyUsesAnEmDash() {
+        let strings = [
+            AgentConnection.sectionTitle,
+            AgentConnection.killSwitchTitle,
+            AgentConnection.killSwitchCaption,
+            AgentConnection.copyButtonTitle,
+            AgentConnection.copiedButtonTitle,
+            AgentConnection.cursorButtonTitle,
+            AgentConnection.cursorFallbackCaption,
+            AgentConnection.disabledCaption,
+        ]
+        for string in strings {
+            XCTAssertFalse(string.contains("—"), string)
+        }
+    }
+
+    func testTheKillSwitchCaptionPromisesApprovalRatherThanSafety() {
+        // The spec's wording, verbatim: it says what happens, not that it is
+        // safe. A caption claiming safety would be the app vouching for
+        // whatever an agent writes.
+        XCTAssertEqual(
+            AgentConnection.killSwitchCaption,
+            "Proposed actions always wait for your approval here before they can run."
+        )
+    }
+}

--- a/Cai/CaiTests/AgentConnectionTests.swift
+++ b/Cai/CaiTests/AgentConnectionTests.swift
@@ -48,17 +48,29 @@ final class AgentConnectionTests: XCTestCase {
 
     // MARK: - Per-client shape
 
-    func testClaudeCodeGetsACommandToRun() {
+    func testClaudeCodeGetsAUserScopedCommandToRun() {
+        // --scope user, because the default is local: Cai is system-wide, and
+        // a local-scoped connection silently vanishes outside the directory
+        // the command happened to be run from.
         XCTAssertEqual(
             AgentConnection.snippet(for: .claudeCode, home: home),
-            "claude mcp add cai -- ~/Library/Application\\ Support/Cai/bin/cai-mcp"
+            "claude mcp add --scope user cai -- ~/Library/Application\\ Support/Cai/bin/cai-mcp"
+        )
+    }
+
+    func testCodexGetsItsOwnCLICommandBecauseItDoesNotReadJSON() {
+        // Codex reads TOML from ~/.codex/config.toml; the JSON payload would
+        // never load there. Its CLI writes the right format itself.
+        XCTAssertEqual(
+            AgentConnection.snippet(for: .codex, home: home),
+            "codex mcp add cai -- ~/Library/Application\\ Support/Cai/bin/cai-mcp"
         )
     }
 
     func testThereIsOneTabPerDistinctThingToDo() {
         // Claude Desktop used to have its own tab showing byte-identical JSON
-        // to "Other". Three tabs, two payloads.
-        XCTAssertEqual(AgentClient.allCases.count, 3)
+        // to "Other". Four tabs, four distinct payloads or delivery methods.
+        XCTAssertEqual(AgentClient.allCases.count, 4)
         XCTAssertEqual(
             AgentConnection.snippet(for: .cursor, home: home),
             AgentConnection.snippet(for: .other, home: home),
@@ -104,11 +116,46 @@ final class AgentConnectionTests: XCTestCase {
         XCTAssertEqual(config["command"], "/Users/tester/Library/Application Support/Cai/bin/cai-mcp")
     }
 
+    func testTheDeeplinkSurvivesAFormStyleDecoder() throws {
+        // A non-ASCII home path is the only way this payload's base64 grows a
+        // "+", and a form-style decoder reads a bare "+" as a space, so the
+        // config silently stops decoding for exactly those users. Cursor's own
+        // generators percent-encode it; so must we.
+        let home = URL(fileURLWithPath: "/Users/田中")
+        let url = try XCTUnwrap(AgentConnection.cursorInstallURL(home: home))
+        let query = try XCTUnwrap(url.query)
+
+        XCTAssertFalse(
+            query.contains("+"),
+            "A bare + in the query is a space to a form-style decoder: \(url.absoluteString)"
+        )
+
+        // Decode the way a form decoder would: percent-decode, then base64.
+        let encoded = try XCTUnwrap(
+            query.split(separator: "&")
+                .first { $0.hasPrefix("config=") }?
+                .dropFirst("config=".count)
+        )
+        let decoded = try XCTUnwrap(String(encoded).removingPercentEncoding)
+        let data = try XCTUnwrap(Data(base64Encoded: decoded))
+        let config = try XCTUnwrap(try JSONSerialization.jsonObject(with: data) as? [String: String])
+        XCTAssertEqual(config["command"], "/Users/田中/Library/Application Support/Cai/bin/cai-mcp")
+    }
+
+    // MARK: - The instructions and the installer agree
+
+    func testTheDisplayedPathIsWhereTheInstallerActuallyWrites() {
+        // AgentConnection derives the path from $HOME; HelperInstaller creates
+        // the symlink under CaiSupportPaths.root. They resolve identically only
+        // while the app is unsandboxed — this pins the two together so a future
+        // support-root change cannot ship instructions pointing at nothing.
+        XCTAssertEqual(AgentConnection.helperPath(), CaiSupportPaths.helperSymlink().path)
+    }
+
     // MARK: - Copy
 
     func testNoConnectCopyUsesAnEmDash() {
         let strings = [
-            AgentConnection.sectionTitle,
             AgentConnection.killSwitchTitle,
             AgentConnection.killSwitchCaption,
             AgentConnection.copyButtonTitle,
@@ -116,6 +163,7 @@ final class AgentConnectionTests: XCTestCase {
             AgentConnection.cursorButtonTitle,
             AgentConnection.cursorFallbackCaption,
             AgentConnection.disabledCaption,
+            AgentConnection.helperMissingCaption,
         ]
         for string in strings {
             XCTAssertFalse(string.contains("—"), string)

--- a/Cai/CaiTests/CaiActionCoreApprovalTierTests.swift
+++ b/Cai/CaiTests/CaiActionCoreApprovalTierTests.swift
@@ -105,7 +105,7 @@ final class ApprovalTierTests: XCTestCase {
             TierCase(
                 label: "prompt chaining into a name nothing resolves to",
                 action: CoreFixture.snapshot(next: [.action(name: "Not installed")]),
-                expected: [],
+                expected: [.chainsToUnknownAction],
                 line: #line
             ),
             TierCase(
@@ -115,9 +115,12 @@ final class ApprovalTierTests: XCTestCase {
                     value: "say hi",
                     autoReplaceSelection: true,
                     runInBackground: true,
-                    next: [.action(name: "Slack")]
+                    next: [.action(name: "Slack"), .action(name: "Not installed")]
                 ),
-                expected: [.runsShellCommands, .sendsSelectionToURL, .replacesSelection, .runsWithoutShowingOutput],
+                expected: [
+                    .runsShellCommands, .sendsSelectionToURL, .replacesSelection,
+                    .runsWithoutShowingOutput, .chainsToUnknownAction,
+                ],
                 line: #line
             ),
         ]
@@ -180,6 +183,31 @@ final class ApprovalTierTests: XCTestCase {
             ApprovalClassifier.escalationReasons(for: proposal, known: known),
             [.runsShellCommands],
             "The chain step resolves to the user's existing shell action, not to the proposal itself."
+        )
+    }
+
+    /// The staging attack the unknown-name escalation exists to stop: propose
+    /// harmless-looking B chaining to "X" before X exists, get B approved on
+    /// one click, then propose shell action X. B now reaches shell and its
+    /// callout never appeared. The first approval is where the blind handoff
+    /// is visible, so that is where the interlock goes.
+    func testAChainStepNoOneHasClaimedYetEscalatesOnItsOwn() {
+        let before = CoreFixture.snapshot(name: "Tidy up", type: .prompt, next: [.action(name: "X")])
+        let empty = KnownActions(shortcuts: [], destinations: [], builtInActionNames: [])
+
+        XCTAssertEqual(
+            ApprovalClassifier.escalationReasons(for: before, known: empty),
+            [.chainsToUnknownAction]
+        )
+        XCTAssertEqual(ApprovalClassifier.tier(for: before, known: empty), .escalated)
+
+        // Once X is installed the reason changes to what X actually is, so
+        // the user is never told less than the truth in either order.
+        let x = CoreFixture.snapshot(id: CoreFixture.otherId, name: "X", type: .shell, value: "./x.sh")
+        let after = KnownActions(shortcuts: [x], destinations: [], builtInActionNames: [])
+        XCTAssertEqual(
+            ApprovalClassifier.escalationReasons(for: before, known: after),
+            [.runsShellCommands]
         )
     }
 

--- a/Cai/CaiTests/PendingChangeStoreTests.swift
+++ b/Cai/CaiTests/PendingChangeStoreTests.swift
@@ -466,7 +466,11 @@ final class PendingChangeStoreTests: XCTestCase {
         store.refresh()
 
         XCTAssertEqual(store.pending.count, 2)
-        XCTAssertEqual(store.pending[1].tier, .standard, "Deploy does not exist yet, so the step resolves to nothing.")
+        XCTAssertEqual(
+            store.pending[1].validated.escalationReasons,
+            [.chainsToUnknownAction],
+            "Deploy does not exist yet: a blind handoff escalates on its own, so approving out of order is never one click either."
+        )
 
         XCTAssertEqual(
             store.approve(store.pending[0], acknowledged: [.runsShellCommands]),
@@ -475,9 +479,9 @@ final class PendingChangeStoreTests: XCTestCase {
 
         XCTAssertEqual(store.pending.count, 1)
         XCTAssertEqual(
-            store.pending[0].tier,
-            .escalated,
-            "The survivor now chains into a shell action and must say so before the user can click again."
+            store.pending[0].validated.escalationReasons,
+            [.runsShellCommands],
+            "The survivor now chains into a real shell action and must say that, not the unknown-name claim the user may have ticked."
         )
     }
 


### PR DESCRIPTION
Connectors covered Cai reaching out to tools, but an agent reaching into Cai had no home in Settings. One "MCP" row now opens a two-tab screen: Client (the existing connectors) and Server (connect your agent), reusing the management shell Actions and Destinations already use.

The Server tab hands the user a per-client payload: a CLI command for Claude Code (user-scoped) and Codex, a one-click install deeplink for Cursor with the JSON as fallback, and a plain JSON object for everything else. Payloads are pure and table-tested because a wrong path or bad quoting produces a config that never loads, and that failure only ever surfaces inside the user's agent.

### Notable decisions:

- Every instruction names the stable symlink, never the app bundle, so configs survive moves and updates. The tab re-links the helper on appear and warns instead of showing a path that resolves to nothing.
- The kill switch leads the screen: nothing an agent proposes can run until approved in Cai.
- The missing-API-key redirect opens the Client tab directly, keeping the old Connectors behavior.
- Claude Desktop lost its own tab (it was byte-identical JSON to "Other"); Codex gained one because it reads TOML and the JSON would never load.
- The Cursor deeplink percent-encodes "+" in the base64 config, since form-style decoders read a bare one as a space.

### Also on this branch: approval sheet

- The per-risk checkboxes collapsed into one acknowledgment ("I understand what this action can do"). Ticking three boxes in a row becomes muscle memory faster than one deliberate act does, and each label repeated the callout sitting directly above it. The interlock still gates Approve on the escalated tier and still resets on any card change.
- The queue can be browsed with chevrons or arrow keys. Deciding stays one at a time, acknowledgments never survive a card change, and the position clamps as proposals arrive and leave.

### Pre-landing review fixes

- A chain step naming an action that doesn't exist yet now escalates (new `chainsToUnknownAction` callout). Before, an agent could get "harmless B chaining to X" approved on one click and then propose shell action X; B reached shell without its callout ever appearing. The browse arrows reopened one ordering of this, but the agent's control of proposal order always allowed the other, so the fix went into the classifier rather than the UI.
- The copyable JSON snippet JSON-encodes the helper path, so a home directory with a quote or backslash cannot produce a config that silently never loads.
- A cancelled disarm timer no longer arms Approve for the card that replaced it; stepping the queue cancels that timer on every arrow press, which made the race routine.
- The Client tab badge re-reads the Keychain right after a key is saved instead of on the next tab switch.

Tests: full suite green, including 16 AgentConnectionTests covering paths, escaping, per-client payloads, and the deeplink encoding, plus classifier and store coverage for the unknown-chain escalation in both decision orders.
