### PR TITLE
Refactor/shell runner

### DIFF
--- a/Cai/Cai/Services/ChainExecutor.swift
+++ b/Cai/Cai/Services/ChainExecutor.swift
@@ -535,53 +535,20 @@ final class ChainExecutor {
             sourceBundleId: sourceBundleId
         )
 
-        let process = Process()
-        process.executableURL = URL(fileURLWithPath: "/bin/zsh")
-        process.arguments = ["-c", resolved]
+        // Stdin = pipe value (so users can `cat`-style consume it in their command).
+        let output = try await ShellRunner.run(resolved, stdin: input)
 
-        // Stdin = pipe value (so users can `cat`-style consume it in their command)
-        let inputPipe = Pipe()
-        let inputData = input.data(using: .utf8) ?? Data()
-        inputPipe.fileHandleForWriting.write(inputData)
-        inputPipe.fileHandleForWriting.closeFile()
-        process.standardInput = inputPipe
-
-        let outputPipe = Pipe()
-        let errorPipe = Pipe()
-        process.standardOutput = outputPipe
-        process.standardError = errorPipe
-
-        try process.run()
-
-        // 60s timeout — same as runShellCommand. Generous buffer for |llm
-        // cold start + the actual command (e.g., `say` reading a sentence).
-        let exitTask = Task.detached { process.waitUntilExit() }
-        let timeoutTask = Task.detached {
-            try await Task.sleep(nanoseconds: 60 * 1_000_000_000)
-            process.terminate()
+        if output.timedOut {
+            throw ShellRunner.timeoutError()
         }
-        await exitTask.value
-        timeoutTask.cancel()
 
-        if process.terminationReason == .uncaughtSignal {
-            throw NSError(domain: "Cai", code: 1, userInfo: [
-                NSLocalizedDescriptionKey: "Shell command exceeded 60s and was stopped"
+        guard output.status == 0 else {
+            throw NSError(domain: "Cai", code: Int(output.status), userInfo: [
+                NSLocalizedDescriptionKey: output.failureMessage
             ])
         }
 
-        let stdout = String(data: outputPipe.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8) ?? ""
-        let stderr = String(data: errorPipe.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8) ?? ""
-
-        guard process.terminationStatus == 0 else {
-            let message = stderr.isEmpty
-                ? "Command failed with exit code \(process.terminationStatus)"
-                : stderr
-            throw NSError(domain: "Cai", code: Int(process.terminationStatus), userInfo: [
-                NSLocalizedDescriptionKey: message
-            ])
-        }
-
-        return stdout.trimmingCharacters(in: .whitespacesAndNewlines)
+        return output.trimmedStdout
     }
 
     // MARK: - Prompt shortcut runner

--- a/Cai/Cai/Services/ChainExecutor.swift
+++ b/Cai/Cai/Services/ChainExecutor.swift
@@ -523,9 +523,6 @@ final class ChainExecutor {
     }
 
     // MARK: - Shell shortcut runner
-    //
-    // Mirrors `ActionListWindow.runShellCommand`. TODO: extract to a shared
-    // ShellRunner helper in v1.7 polish — right now there are two copies.
 
     private func runShell(template: String, input: String, sourceBundleId: String?) async throws -> String {
         let resolved = try await TemplateEngine.render(

--- a/Cai/Cai/Services/OutputDestinationService.swift
+++ b/Cai/Cai/Services/OutputDestinationService.swift
@@ -226,44 +226,16 @@ actor OutputDestinationService {
             context: .shell, sourceBundleId: sourceBundleId
         )
 
-        let process = Process()
-        process.executableURL = URL(fileURLWithPath: "/bin/zsh")
-        process.arguments = ["-c", resolved]
-        process.environment = Self.shellEnvironment()
+        // stderr is merged into stdout here, unlike the action paths: a failing
+        // destination reports one combined stream to the user.
+        let output = try await ShellRunner.run(resolved, stdin: text, mergeStderrIntoStdout: true)
 
-        // Pass text as stdin
-        let inputPipe = Pipe()
-        let inputData = text.data(using: .utf8) ?? Data()
-        inputPipe.fileHandleForWriting.write(inputData)
-        inputPipe.fileHandleForWriting.closeFile()
-        process.standardInput = inputPipe
-
-        let outputPipe = Pipe()
-        process.standardOutput = outputPipe
-        process.standardError = outputPipe
-
-        try process.run()
-
-        // Timeout after 60 seconds — comfortable buffer for `|llm` filter cold
-        // starts (~5-15s) plus the shell command itself (e.g. `say` reading a
-        // few sentences). Configurable per-action timeout is Phase 3 work.
-        let exitTask = Task.detached {
-            process.waitUntilExit()
-        }
-        let timeoutTask = Task.detached {
-            try await Task.sleep(nanoseconds: 60 * 1_000_000_000)
-            process.terminate()
-        }
-        await exitTask.value
-        timeoutTask.cancel()
-
-        if process.terminationReason == .uncaughtSignal {
+        if output.timedOut {
             throw OutputDestinationError.timeout
         }
 
-        guard process.terminationStatus == 0 else {
-            let output = String(data: outputPipe.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8) ?? ""
-            throw OutputDestinationError.shellFailed(Int(process.terminationStatus), output)
+        guard output.status == 0 else {
+            throw OutputDestinationError.shellFailed(Int(output.status), output.stdout)
         }
     }
 

--- a/Cai/Cai/Services/ShellRunner.swift
+++ b/Cai/Cai/Services/ShellRunner.swift
@@ -1,4 +1,5 @@
 import Foundation
+import os
 
 /// The one place Cai runs a shell command.
 ///
@@ -13,20 +14,54 @@ import Foundation
 /// only after `waitUntilExit()`, which deadlocks as soon as a command writes
 /// more than the pipe buffer holds (~64KB): the command blocks on a full pipe,
 /// we block waiting for it to exit. That is CAI-15, and it is fixed here rather
-/// than in three places. Same for stdin, which is written from its own task
-/// because a large input blocks until something reads the other end.
+/// than in three places. Same for stdin, which is written concurrently because
+/// a large input blocks until something reads the other end.
+///
+/// **`run` always returns.** Three things used to be able to park it forever:
+/// a command that traps SIGTERM (the timeout's terminate did nothing), a
+/// pipeline whose children outlive zsh after a timeout (they hold the pipe
+/// write ends, so the drain never sees EOF), and a command that backgrounds a
+/// child and exits (same, on the success path). So the timeout escalates to
+/// SIGKILL, and once the process has exited the drains get a short deadline:
+/// anything the command wrote is already in the pipe buffer and arrives
+/// instantly, so only a live orphan can still be holding the pipe open, and we
+/// return what was collected rather than wait on a process we don't own.
+/// All pipe I/O goes through `DispatchIO`, which can be torn down at that
+/// deadline; blocking reads on a queue would park their threads forever in
+/// exactly these cases.
 enum ShellRunner {
 
     /// 60 seconds. Comfortable buffer for a `|llm` filter cold start (~5-15s)
     /// plus the command itself. Per-action timeouts are later work.
     static let defaultTimeout: TimeInterval = 60
 
+    /// Per-stream cap, 10 MB. The old copies had an accidental ceiling: past
+    /// ~64KB they deadlocked and the timeout killed the command. Draining
+    /// properly removes that dam, so the cap is what keeps `cat hugefile` from
+    /// ballooning memory and freezing ResultView. Same principle as
+    /// `ClipboardHistory.maxTextLength`, sized for command output.
+    static let maxOutputBytes = 10 * 1024 * 1024
+
+    /// Appended to a stream that hit `maxOutputBytes`. The rest was drained and
+    /// discarded so the command still ran to completion.
+    static let truncationMarker = "\n[output truncated at 10 MB]"
+
+    /// How long after SIGTERM before SIGKILL. SIGTERM is trappable; a command
+    /// that ignores it would otherwise block `waitUntilExit` forever.
+    private static let killGrace: TimeInterval = 2
+
+    /// How long after process exit the drains may wait for EOF. Buffered data
+    /// arrives in microseconds; the deadline only fires when a surviving child
+    /// still holds a pipe end, and waiting on those means hanging forever.
+    private static let drainDeadline: TimeInterval = 1
+
     struct Output {
         let status: Int32
         let stdout: String
         let stderr: String
-        /// The process was killed by a signal, which in practice means our
-        /// timeout fired. Kept as the same heuristic the three copies used.
+        /// Our timeout fired for this command. Set by the timeout itself, not
+        /// inferred from the termination reason: a command that segfaults dies
+        /// by signal too and used to be misreported as "exceeded 60s".
         let timedOut: Bool
 
         /// stdout with surrounding whitespace removed, which is what every
@@ -75,78 +110,76 @@ enum ShellRunner {
         process.standardError = errorPipe
 
         // Writing to a pipe whose reader is gone raises SIGPIPE, which kills the
-        // whole app rather than failing the command. That became reachable the
-        // moment stdin moved after `run()`: a command that exits without reading
-        // it, a mistyped command name for instance, closes the read end first.
-        // F_SETNOSIGPIPE turns the signal into an EPIPE we can swallow, which is
-        // the right outcome because the command was never listening.
+        // whole app rather than failing the command: a command that exits
+        // without reading stdin, a mistyped command name for instance, closes
+        // the read end first. F_SETNOSIGPIPE turns the signal into an EPIPE the
+        // writer can swallow, which is the right outcome because the command was
+        // never listening.
         _ = fcntl(inputPipe.fileHandleForWriting.fileDescriptor, F_SETNOSIGPIPE, 1)
 
         try process.run()
 
-        // Write stdin and read both streams concurrently with the process, or a
-        // command whose input or output exceeds the pipe buffer never finishes:
-        // it blocks on a full pipe while we wait for it to exit.
-        //
-        // All four of these block their thread, so they go to a dedicated
-        // concurrent queue rather than `Task.detached`. Detached tasks run on the
-        // cooperative pool, which has roughly one thread per core, and four
-        // blocking calls per invocation exhaust it: tasks stop being scheduled
-        // and the runner hangs. Only the timeout stays a Task, because
-        // `Task.sleep` suspends instead of blocking.
-        async let stdoutData = readToEnd(outputPipe.fileHandleForReading)
-        async let stderrData = mergeStderrIntoStdout ? Data() : readToEnd(errorPipe.fileHandleForReading)
-        async let stdinWritten: Void = write(stdin, to: inputPipe.fileHandleForWriting)
+        let stdoutReader = PipeReader(outputPipe.fileHandleForReading, cap: maxOutputBytes)
+        let stderrReader = mergeStderrIntoStdout ? nil : PipeReader(errorPipe.fileHandleForReading, cap: maxOutputBytes)
+        let stdinWriter = PipeWriter(inputPipe.fileHandleForWriting, data: stdin.data(using: .utf8) ?? Data())
 
+        let timedOutFlag = OSAllocatedUnfairLock(initialState: false)
         let timeoutTask = Task {
-            try await Task.sleep(nanoseconds: UInt64(timeout * 1_000_000_000))
+            try await Task.sleep(nanoseconds: UInt64(max(0, timeout) * 1_000_000_000))
+            timedOutFlag.withLock { $0 = true }
             process.terminate()
+            try await Task.sleep(nanoseconds: UInt64(killGrace * 1_000_000_000))
+            if process.isRunning {
+                kill(process.processIdentifier, SIGKILL)
+            }
         }
         await waitForExit(process)
         timeoutTask.cancel()
+        let timedOut = timedOutFlag.withLock { $0 }
 
-        await stdinWritten
-        let outData = await stdoutData
-        let errData = await stderrData
+        // Drain deadline: normally EOF is already there and this costs nothing;
+        // a surviving child holding a pipe end is the only thing that can make
+        // it fire, and that child may never exit.
+        let deadline = Task {
+            try await Task.sleep(nanoseconds: UInt64(drainDeadline * 1_000_000_000))
+            stdoutReader.stop()
+            stderrReader?.stop()
+            stdinWriter.stop()
+        }
+        await stdoutReader.waitUntilEOF()
+        await stderrReader?.waitUntilEOF()
+        await stdinWriter.waitUntilDone()
+        deadline.cancel()
+
+        let (outData, outTruncated) = stdoutReader.result()
+        let (errData, errTruncated) = stderrReader?.result() ?? (Data(), false)
+
+        // Lossy decode: a single invalid byte used to nil the whole string, so
+        // Latin-1 error text or binary output became "" with no trace.
+        var stdout = String(decoding: outData, as: UTF8.self)
+        if outTruncated { stdout += truncationMarker }
+        var stderr = String(decoding: errData, as: UTF8.self)
+        if errTruncated { stderr += truncationMarker }
 
         return Output(
             status: process.terminationStatus,
-            stdout: String(data: outData, encoding: .utf8) ?? "",
-            stderr: String(data: errData, encoding: .utf8) ?? "",
-            timedOut: process.terminationReason == .uncaughtSignal
+            stdout: stdout,
+            stderr: stderr,
+            timedOut: timedOut
         )
     }
 
-    // MARK: - Blocking I/O, off the cooperative pool
+    // MARK: - Process exit, off the cooperative pool
 
-    /// Serves the reads, the write, and `waitUntilExit`. Concurrent, because one
-    /// invocation needs three of them at once and they all block.
+    /// `waitUntilExit` blocks its thread, so it goes to a dedicated queue rather
+    /// than `Task.detached`: detached tasks run on the cooperative pool, which
+    /// has roughly one thread per core, and blocking there stops other tasks
+    /// from being scheduled. Bounded by the SIGKILL escalation above. Concurrent
+    /// because several commands can be in flight at once.
     private static let ioQueue = DispatchQueue(
         label: "com.soyasis.cai.shell",
         attributes: .concurrent
     )
-
-    private static func readToEnd(_ handle: FileHandle) async -> Data {
-        await withCheckedContinuation { continuation in
-            ioQueue.async {
-                continuation.resume(returning: (try? handle.readToEnd()) ?? Data())
-            }
-        }
-    }
-
-    private static func write(_ text: String, to handle: FileHandle) async {
-        await withCheckedContinuation { continuation in
-            ioQueue.async {
-                if let data = text.data(using: .utf8), !data.isEmpty {
-                    // Throws EPIPE when the command exited without reading. That
-                    // is not an error worth surfacing: it was not listening.
-                    try? handle.write(contentsOf: data)
-                }
-                try? handle.close()
-                continuation.resume()
-            }
-        }
-    }
 
     private static func waitForExit(_ process: Process) async {
         await withCheckedContinuation { continuation in
@@ -166,5 +199,125 @@ enum ShellRunner {
         NSError(domain: "Cai", code: 1, userInfo: [
             NSLocalizedDescriptionKey: "Shell command exceeded \(Int(seconds))s and was stopped"
         ])
+    }
+}
+
+// MARK: - Pipe I/O
+
+/// Accumulates one pipe's output via `DispatchIO`, up to a cap (the rest is
+/// drained and discarded so the command never blocks on a full pipe). No thread
+/// is parked while waiting, so `stop()` can always tear the channel down and
+/// hand back whatever arrived.
+private final class PipeReader {
+    private let queue = DispatchQueue(label: "com.soyasis.cai.shell.read")
+    private let io: DispatchIO
+    private var data = Data()
+    private var truncated = false
+    private var finished = false
+    private var waiter: CheckedContinuation<Void, Never>?
+
+    init(_ handle: FileHandle, cap: Int) {
+        // The cleanup handler owns closing the fd; capturing the handle keeps
+        // the descriptor alive for as long as the channel needs it.
+        io = DispatchIO(type: .stream, fileDescriptor: handle.fileDescriptor, queue: queue) { _ in
+            try? handle.close()
+        }
+        io.setLimit(lowWater: 1)
+        io.read(offset: 0, length: Int.max, queue: queue) { [self] done, chunk, _ in
+            if let chunk, !chunk.isEmpty {
+                if data.count < cap {
+                    let room = cap - data.count
+                    if chunk.count <= room {
+                        data.append(contentsOf: chunk)
+                    } else {
+                        data.append(contentsOf: chunk.prefix(room))
+                        truncated = true
+                    }
+                } else {
+                    truncated = true
+                }
+            }
+            if done { finish() }
+        }
+    }
+
+    /// Resolves at EOF, on a read error, or when `stop()` tears the channel down.
+    func waitUntilEOF() async {
+        await withCheckedContinuation { continuation in
+            queue.async { [self] in
+                if finished { continuation.resume() } else { waiter = continuation }
+            }
+        }
+    }
+
+    /// Cancels the outstanding read. The handler fires once more with `done`,
+    /// which resolves the waiter with whatever was collected.
+    func stop() {
+        queue.async { [self] in
+            guard !finished else { return }
+            io.close(flags: .stop)
+        }
+    }
+
+    func result() -> (data: Data, truncated: Bool) {
+        queue.sync { (data, truncated) }
+    }
+
+    private func finish() {
+        guard !finished else { return }
+        finished = true
+        io.close()
+        waiter?.resume()
+        waiter = nil
+    }
+}
+
+/// Writes stdin via `DispatchIO` and closes the write end when done, so the
+/// command sees EOF. A command that exits without reading turns the write into
+/// EPIPE (thanks to F_SETNOSIGPIPE), which ends the write; that is not an error
+/// worth surfacing, the command was not listening.
+private final class PipeWriter {
+    private let queue = DispatchQueue(label: "com.soyasis.cai.shell.write")
+    private var io: DispatchIO?
+    private var finished = false
+    private var waiter: CheckedContinuation<Void, Never>?
+
+    init(_ handle: FileHandle, data: Data) {
+        guard !data.isEmpty else {
+            try? handle.close()
+            finished = true
+            return
+        }
+        let channel = DispatchIO(type: .stream, fileDescriptor: handle.fileDescriptor, queue: queue) { _ in
+            try? handle.close()
+        }
+        io = channel
+        let dispatchData = data.withUnsafeBytes { DispatchData(bytes: $0) }
+        channel.write(offset: 0, data: dispatchData, queue: queue) { [self] done, _, _ in
+            if done { finish() }
+        }
+    }
+
+    func waitUntilDone() async {
+        await withCheckedContinuation { continuation in
+            queue.async { [self] in
+                if finished { continuation.resume() } else { waiter = continuation }
+            }
+        }
+    }
+
+    func stop() {
+        queue.async { [self] in
+            guard !finished else { return }
+            io?.close(flags: .stop)
+        }
+    }
+
+    private func finish() {
+        guard !finished else { return }
+        finished = true
+        io?.close()
+        waiter?.resume()
+        waiter = nil
     }
 }

--- a/Cai/Cai/Services/ShellRunner.swift
+++ b/Cai/Cai/Services/ShellRunner.swift
@@ -1,0 +1,170 @@
+import Foundation
+
+/// The one place Cai runs a shell command.
+///
+/// This existed three times over (shell shortcut, chain shell step, shell
+/// destination) and the copies had already drifted: the chain step never set
+/// the Homebrew PATH, so a `gh` or `jq` command that worked as a standalone
+/// action failed inside a chain with "command not found". Extracting it is what
+/// keeps the next change from having to be made three times and remembered
+/// twice.
+///
+/// **Output is drained while the process runs.** All three copies read stdout
+/// only after `waitUntilExit()`, which deadlocks as soon as a command writes
+/// more than the pipe buffer holds (~64KB): the command blocks on a full pipe,
+/// we block waiting for it to exit. That is CAI-15, and it is fixed here rather
+/// than in three places. Same for stdin, which is written from its own task
+/// because a large input blocks until something reads the other end.
+enum ShellRunner {
+
+    /// 60 seconds. Comfortable buffer for a `|llm` filter cold start (~5-15s)
+    /// plus the command itself. Per-action timeouts are later work.
+    static let defaultTimeout: TimeInterval = 60
+
+    struct Output {
+        let status: Int32
+        let stdout: String
+        let stderr: String
+        /// The process was killed by a signal, which in practice means our
+        /// timeout fired. Kept as the same heuristic the three copies used.
+        let timedOut: Bool
+
+        /// stdout with surrounding whitespace removed, which is what every
+        /// caller that propagates output actually wants.
+        var trimmedStdout: String {
+            stdout.trimmingCharacters(in: .whitespacesAndNewlines)
+        }
+
+        /// stderr if the command wrote any, otherwise a generic exit-code
+        /// message. The shape all three copies built by hand.
+        var failureMessage: String {
+            let text = stderr.trimmingCharacters(in: .whitespacesAndNewlines)
+            return text.isEmpty ? "Command failed with exit code \(status)" : stderr
+        }
+    }
+
+    /// Runs `command` through `/bin/zsh -c`.
+    ///
+    /// - Parameters:
+    ///   - command: the fully resolved command line. Templates must already be
+    ///     rendered; this function does no substitution and no escaping.
+    ///   - stdin: piped to the command, so a user can consume it `cat`-style.
+    ///   - environment: defaults to `OutputDestinationService.shellEnvironment()`,
+    ///     which prepends the Homebrew paths that non-interactive zsh lacks.
+    ///   - mergeStderrIntoStdout: shell destinations report one combined stream
+    ///     on failure and relied on a single pipe to interleave it. Preserved so
+    ///     the extraction changes no output.
+    ///   - timeout: seconds before the process is terminated.
+    static func run(
+        _ command: String,
+        stdin: String,
+        environment: [String: String]? = nil,
+        mergeStderrIntoStdout: Bool = false,
+        timeout: TimeInterval = defaultTimeout
+    ) async throws -> Output {
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/bin/zsh")
+        process.arguments = ["-c", command]
+        process.environment = environment ?? OutputDestinationService.shellEnvironment()
+
+        let inputPipe = Pipe()
+        let outputPipe = Pipe()
+        let errorPipe = mergeStderrIntoStdout ? outputPipe : Pipe()
+        process.standardInput = inputPipe
+        process.standardOutput = outputPipe
+        process.standardError = errorPipe
+
+        // Writing to a pipe whose reader is gone raises SIGPIPE, which kills the
+        // whole app rather than failing the command. That became reachable the
+        // moment stdin moved after `run()`: a command that exits without reading
+        // it, a mistyped command name for instance, closes the read end first.
+        // F_SETNOSIGPIPE turns the signal into an EPIPE we can swallow, which is
+        // the right outcome because the command was never listening.
+        _ = fcntl(inputPipe.fileHandleForWriting.fileDescriptor, F_SETNOSIGPIPE, 1)
+
+        try process.run()
+
+        // Write stdin and read both streams concurrently with the process, or a
+        // command whose input or output exceeds the pipe buffer never finishes:
+        // it blocks on a full pipe while we wait for it to exit.
+        //
+        // All four of these block their thread, so they go to a dedicated
+        // concurrent queue rather than `Task.detached`. Detached tasks run on the
+        // cooperative pool, which has roughly one thread per core, and four
+        // blocking calls per invocation exhaust it: tasks stop being scheduled
+        // and the runner hangs. Only the timeout stays a Task, because
+        // `Task.sleep` suspends instead of blocking.
+        async let stdoutData = readToEnd(outputPipe.fileHandleForReading)
+        async let stderrData = mergeStderrIntoStdout ? Data() : readToEnd(errorPipe.fileHandleForReading)
+        async let stdinWritten: Void = write(stdin, to: inputPipe.fileHandleForWriting)
+
+        let timeoutTask = Task {
+            try await Task.sleep(nanoseconds: UInt64(timeout * 1_000_000_000))
+            process.terminate()
+        }
+        await waitForExit(process)
+        timeoutTask.cancel()
+
+        await stdinWritten
+        let outData = await stdoutData
+        let errData = await stderrData
+
+        return Output(
+            status: process.terminationStatus,
+            stdout: String(data: outData, encoding: .utf8) ?? "",
+            stderr: String(data: errData, encoding: .utf8) ?? "",
+            timedOut: process.terminationReason == .uncaughtSignal
+        )
+    }
+
+    // MARK: - Blocking I/O, off the cooperative pool
+
+    /// Serves the reads, the write, and `waitUntilExit`. Concurrent, because one
+    /// invocation needs three of them at once and they all block.
+    private static let ioQueue = DispatchQueue(
+        label: "com.soyasis.cai.shell",
+        attributes: .concurrent
+    )
+
+    private static func readToEnd(_ handle: FileHandle) async -> Data {
+        await withCheckedContinuation { continuation in
+            ioQueue.async {
+                continuation.resume(returning: (try? handle.readToEnd()) ?? Data())
+            }
+        }
+    }
+
+    private static func write(_ text: String, to handle: FileHandle) async {
+        await withCheckedContinuation { continuation in
+            ioQueue.async {
+                if let data = text.data(using: .utf8), !data.isEmpty {
+                    // Throws EPIPE when the command exited without reading. That
+                    // is not an error worth surfacing: it was not listening.
+                    try? handle.write(contentsOf: data)
+                }
+                try? handle.close()
+                continuation.resume()
+            }
+        }
+    }
+
+    private static func waitForExit(_ process: Process) async {
+        await withCheckedContinuation { continuation in
+            ioQueue.async {
+                process.waitUntilExit()
+                continuation.resume()
+            }
+        }
+    }
+
+    /// The error every caller that surfaces a timeout to the user throws.
+    ///
+    /// Phrasing avoids "timed out" deliberately: `ResultView`'s provider-error
+    /// heuristic matches that phrase and would show a misleading
+    /// "Check Settings → Model Provider" hint.
+    static func timeoutError(seconds: TimeInterval = defaultTimeout) -> NSError {
+        NSError(domain: "Cai", code: 1, userInfo: [
+            NSLocalizedDescriptionKey: "Shell command exceeded \(Int(seconds))s and was stopped"
+        ])
+    }
+}

--- a/Cai/Cai/Views/ActionListWindow.swift
+++ b/Cai/Cai/Views/ActionListWindow.swift
@@ -1941,57 +1941,20 @@ struct ActionListWindow: View {
             sourceBundleId: sourceBundleId
         )
 
-        let process = Process()
-        process.executableURL = URL(fileURLWithPath: "/bin/zsh")
-        process.arguments = ["-c", resolved]
-        // Prepend Homebrew paths to PATH — non-interactive zsh doesn't source
-        // .zshrc, so gh/jq/kubectl etc. are otherwise unreachable without
-        // hardcoded absolute paths. See `OutputDestinationService.shellEnvironment`.
-        process.environment = OutputDestinationService.shellEnvironment()
+        // Text goes in as stdin. The runner supplies the Homebrew PATH that
+        // non-interactive zsh lacks.
+        let output = try await ShellRunner.run(resolved, stdin: text)
 
-        // Pass text as stdin
-        let inputPipe = Pipe()
-        let inputData = text.data(using: .utf8) ?? Data()
-        inputPipe.fileHandleForWriting.write(inputData)
-        inputPipe.fileHandleForWriting.closeFile()
-        process.standardInput = inputPipe
-
-        let outputPipe = Pipe()
-        let errorPipe = Pipe()
-        process.standardOutput = outputPipe
-        process.standardError = errorPipe
-
-        try process.run()
-
-        // Timeout after 60 seconds — comfortable buffer for `|llm` filter cold
-        // starts (~5-15s) plus the shell command itself (e.g. `say` reading a
-        // few sentences). Configurable per-action timeout is Phase 3 work.
-        let exitTask = Task.detached {
-            process.waitUntilExit()
+        if output.timedOut {
+            throw ShellRunner.timeoutError()
         }
-        let timeoutTask = Task.detached {
-            try await Task.sleep(nanoseconds: 60 * 1_000_000_000)
-            process.terminate()
-        }
-        await exitTask.value
-        timeoutTask.cancel()
 
-        if process.terminationReason == .uncaughtSignal {
-            // Phrasing avoids "timed out" so ResultView's provider-error heuristic
-            // doesn't show the misleading "Check Settings → Model Provider" hint.
-            throw NSError(domain: "Cai", code: 1, userInfo: [
-                NSLocalizedDescriptionKey: "Shell command exceeded 60s and was stopped"
+        guard output.status == 0 else {
+            throw NSError(domain: "Cai", code: Int(output.status), userInfo: [
+                NSLocalizedDescriptionKey: output.failureMessage
             ])
         }
 
-        let stdout = String(data: outputPipe.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8) ?? ""
-        let stderr = String(data: errorPipe.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8) ?? ""
-
-        guard process.terminationStatus == 0 else {
-            let message = stderr.isEmpty ? "Command failed with exit code \(process.terminationStatus)" : stderr
-            throw NSError(domain: "Cai", code: Int(process.terminationStatus), userInfo: [NSLocalizedDescriptionKey: message])
-        }
-
-        return stdout.trimmingCharacters(in: .whitespacesAndNewlines)
+        return output.trimmedStdout
     }
 }

--- a/Cai/CaiTests/ShellRunnerTests.swift
+++ b/Cai/CaiTests/ShellRunnerTests.swift
@@ -127,6 +127,73 @@ final class ShellRunnerTests: XCTestCase {
         XCTAssertNotEqual(output.status, 0)
     }
 
+    // MARK: - run() always returns
+
+    func testABackgroundedChildDoesNotBlockTheReturn() async throws {
+        // The orphan inherits the pipe write ends, so there is never an EOF to
+        // wait for. The old destination copy returned instantly here; the drain
+        // deadline is what keeps the extraction from hanging until the orphan dies.
+        let started = Date()
+        let output = try await ShellRunner.run("echo started; sleep 30 &", stdin: "")
+
+        XCTAssertLessThan(Date().timeIntervalSince(started), 10, "run() must not wait for the orphaned child")
+        XCTAssertEqual(output.status, 0)
+        XCTAssertTrue(output.stdout.contains("started"), "output written before zsh exited must still be delivered")
+    }
+
+    func testATimedOutPipelineStillReturns() async throws {
+        // terminate() reaches only zsh; the pipeline children can survive it and
+        // keep the pipes open. The old copies threw the timeout error without
+        // touching the pipes, so this must not regress into an infinite wait.
+        let started = Date()
+        let output = try await ShellRunner.run("sleep 30 | cat", stdin: "", timeout: 1)
+
+        XCTAssertLessThan(Date().timeIntervalSince(started), 10, "the timeout must bound the return, not just the SIGTERM")
+        XCTAssertTrue(output.timedOut)
+    }
+
+    func testACommandThatIgnoresSIGTERMIsForceKilled() async throws {
+        // Ignored-signal dispositions survive exec, so the sleep inherits the
+        // trap and shrugs off terminate(). Without SIGKILL escalation this waits
+        // the full 30s (forever, for a daemon).
+        let started = Date()
+        let output = try await ShellRunner.run("trap '' TERM; sleep 30", stdin: "", timeout: 1)
+
+        XCTAssertLessThan(Date().timeIntervalSince(started), 10, "SIGKILL escalation did not fire")
+        XCTAssertTrue(output.timedOut)
+    }
+
+    func testACrashingCommandIsNotReportedAsATimeout() async throws {
+        // Dies by signal in well under the timeout. The old heuristic inferred
+        // "timed out" from any signal death and fabricated a 60s story.
+        let output = try await ShellRunner.run("kill -SEGV $$", stdin: "")
+
+        XCTAssertFalse(output.timedOut)
+        XCTAssertNotEqual(output.status, 0)
+    }
+
+    // MARK: - Output bounds and decoding
+
+    func testOutputPastTheCapIsTruncatedWithAMarker() async throws {
+        // Fixing the 64KB deadlock removed the accidental ceiling on output, so
+        // the cap is what stands between `cat hugefile` and a ballooning toast.
+        let past = ShellRunner.maxOutputBytes + 1_048_576
+        let output = try await ShellRunner.run("yes a | head -c \(past)", stdin: "")
+
+        XCTAssertEqual(output.status, 0)
+        XCTAssertTrue(output.stdout.hasSuffix(ShellRunner.truncationMarker))
+        XCTAssertEqual(output.stdout.count, ShellRunner.maxOutputBytes + ShellRunner.truncationMarker.count)
+    }
+
+    func testNonUTF8OutputIsDecodedLossilyNotDropped() async throws {
+        // One invalid byte used to nil the whole string: Latin-1 error text
+        // became "" with exit 0, indistinguishable from no output at all.
+        let output = try await ShellRunner.run(#"printf 'caf\xe9'"#, stdin: "")
+
+        XCTAssertTrue(output.stdout.hasPrefix("caf"), "the readable bytes must survive an invalid one")
+        XCTAssertFalse(output.stdout.isEmpty)
+    }
+
     func testTheTimeoutMessageAvoidsTheProviderErrorHeuristic() {
         let message = ShellRunner.timeoutError().localizedDescription
 

--- a/Cai/CaiTests/ShellRunnerTests.swift
+++ b/Cai/CaiTests/ShellRunnerTests.swift
@@ -1,0 +1,136 @@
+import XCTest
+@testable import Cai
+
+/// The single shell path, covering what the three copies it replaced never had
+/// a test for.
+///
+/// The large-output and large-input cases are the point of the extraction: every
+/// previous copy read stdout only after `waitUntilExit()`, which deadlocks once
+/// a command outfills the ~64KB pipe buffer (CAI-15). Both cases hang forever
+/// against the old implementation, so they are the regression guard.
+final class ShellRunnerTests: XCTestCase {
+
+    // MARK: - The deadlock these tests exist for
+
+    func testOutputLargerThanThePipeBufferCompletes() async throws {
+        let byteCount = 200_000  // comfortably past the ~64KB pipe buffer
+        let output = try await ShellRunner.run("yes a | head -c \(byteCount)", stdin: "")
+
+        XCTAssertEqual(output.status, 0)
+        XCTAssertFalse(output.timedOut)
+        XCTAssertEqual(output.stdout.count, byteCount, "output was truncated, which means it was read after exit rather than drained")
+    }
+
+    func testInputLargerThanThePipeBufferCompletes() async throws {
+        let input = String(repeating: "x", count: 200_000)
+        let output = try await ShellRunner.run("wc -c", stdin: input)
+
+        XCTAssertEqual(output.status, 0)
+        XCTAssertEqual(Int(output.trimmedStdout), input.count, "stdin was truncated or the write blocked")
+    }
+
+    func testACommandThatExitsWithoutReadingStdinDoesNotKillTheApp() async throws {
+        // Writing to a pipe with no reader raises SIGPIPE, which takes the whole
+        // process down. This exact case (a nonexistent command, which exits 127
+        // without reading) crashed the test host before F_SETNOSIGPIPE, so if
+        // this test runs to its assertions at all, the guard is working.
+        let output = try await ShellRunner.run("definitely_not_a_real_command_zzz", stdin: "piped value")
+
+        XCTAssertEqual(output.status, 127)
+        XCTAssertTrue(output.stderr.contains("not found"))
+    }
+
+    func testLargeInputToACommandThatIgnoresItStillFinishes() async throws {
+        // The old code wrote stdin synchronously before `run()`, so this blocked
+        // the caller forever. Now the write lives in its own task and ends in
+        // EPIPE when the command exits without reading, which must surface as a
+        // caught error rather than SIGPIPE killing the host process.
+        let output = try await ShellRunner.run("echo done", stdin: String(repeating: "x", count: 200_000))
+
+        XCTAssertEqual(output.status, 0)
+        XCTAssertEqual(output.trimmedStdout, "done")
+    }
+
+    func testLargeStderrDoesNotBlockEither() async throws {
+        let output = try await ShellRunner.run("yes e | head -c 200000 >&2", stdin: "")
+
+        XCTAssertEqual(output.status, 0)
+        XCTAssertEqual(output.stderr.count, 200_000)
+        XCTAssertEqual(output.stdout, "")
+    }
+
+    // MARK: - Streams
+
+    func testStdinReachesTheCommand() async throws {
+        let output = try await ShellRunner.run("cat", stdin: "piped value")
+        XCTAssertEqual(output.trimmedStdout, "piped value")
+    }
+
+    func testStdoutAndStderrStaySeparateByDefault() async throws {
+        let output = try await ShellRunner.run("echo out; echo err >&2", stdin: "")
+
+        XCTAssertEqual(output.trimmedStdout, "out")
+        XCTAssertEqual(output.stderr.trimmingCharacters(in: .whitespacesAndNewlines), "err")
+    }
+
+    func testMergingPutsStderrOnStdout() async throws {
+        let output = try await ShellRunner.run("echo err >&2", stdin: "", mergeStderrIntoStdout: true)
+
+        XCTAssertEqual(output.trimmedStdout, "err", "shell destinations report one combined stream")
+        XCTAssertEqual(output.stderr, "", "nothing is read separately when the pipes are shared")
+    }
+
+    // MARK: - Exit status
+
+    func testNonZeroExitIsReportedNotThrown() async throws {
+        let output = try await ShellRunner.run("exit 3", stdin: "")
+
+        XCTAssertEqual(output.status, 3)
+        XCTAssertFalse(output.timedOut)
+    }
+
+    func testFailureMessagePrefersStderr() async throws {
+        let output = try await ShellRunner.run("echo 'no such thing' >&2; exit 1", stdin: "")
+        XCTAssertTrue(output.failureMessage.contains("no such thing"))
+    }
+
+    func testFailureMessageFallsBackToTheExitCode() async throws {
+        let output = try await ShellRunner.run("exit 42", stdin: "")
+        XCTAssertEqual(output.failureMessage, "Command failed with exit code 42")
+    }
+
+    // MARK: - Environment
+
+    func testHomebrewPathsArePresent() async throws {
+        let output = try await ShellRunner.run("echo $PATH", stdin: "")
+
+        XCTAssertTrue(output.trimmedStdout.contains("/opt/homebrew/bin"), "the chain copy lacked this, so gh and jq failed inside chains")
+        XCTAssertTrue(output.trimmedStdout.contains("/usr/local/bin"))
+    }
+
+    func testAnExplicitEnvironmentReplacesTheDefault() async throws {
+        let output = try await ShellRunner.run(
+            "echo $CAI_TEST_VALUE",
+            stdin: "",
+            environment: ["CAI_TEST_VALUE": "from the environment", "PATH": "/usr/bin:/bin"]
+        )
+
+        XCTAssertEqual(output.trimmedStdout, "from the environment", "the environment is how secrets will reach a command without entering argv")
+    }
+
+    // MARK: - Timeout
+
+    func testATimeoutTerminatesTheCommand() async throws {
+        let output = try await ShellRunner.run("sleep 30", stdin: "", timeout: 1)
+
+        XCTAssertTrue(output.timedOut)
+        XCTAssertNotEqual(output.status, 0)
+    }
+
+    func testTheTimeoutMessageAvoidsTheProviderErrorHeuristic() {
+        let message = ShellRunner.timeoutError().localizedDescription
+
+        XCTAssertTrue(message.contains("exceeded"))
+        XCTAssertFalse(message.lowercased().contains("timed out"), "ResultView matches that phrase and would suggest checking the model provider")
+    }
+}


### PR DESCRIPTION
## What

Extracts the three duplicated shell-execution blocks (shell shortcut, chain shell step, shell destination) into a single `ShellRunner`, and hardens it so `run()` always returns.

The copies had already drifted: the chain step never set the Homebrew PATH, so a `gh` or `jq` command that worked as a standalone action failed inside a chain with "command not found". They also shared CAI-15: stdout was read only after `waitUntilExit()`, which deadlocks any command writing more than the ~64KB pipe buffer.

## Why the runner is more than a copy-paste extraction

Review on this branch (structured + adversarial passes) found the naive extraction traded one hang for another, so the runner now guarantees a bounded return:

- output is drained while the process runs via DispatchIO, fixing the ~64KB deadlock in one place instead of three
- stdin is written concurrently and guarded with F_SETNOSIGPIPE: a command that exits without reading its input used to SIGPIPE-kill the whole app
- the timeout escalates SIGTERM to SIGKILL after 2s, since SIGTERM is trappable and a command ignoring it blocked `waitUntilExit` forever
- drains get a 1s post-exit deadline: buffered output arrives instantly, and only a surviving child (timed-out pipeline, backgrounded daemon) can hold the pipes open, which previously hung the action forever
- `timedOut` is set by the timeout task itself instead of inferred from signal death, so a crashing command is no longer reported as "exceeded 60s"
- each stream is capped at 10MB with a truncation marker, because fixing the deadlock removed the accidental output ceiling that used to protect memory and the result UI
- output decodes lossily instead of nil-ing on the first invalid byte, so Latin-1 error text no longer becomes an empty string
- the chain step gains the Homebrew PATH the other two paths already had, and the destination path keeps its merged stderr stream

## Tests

`ShellRunnerTests` (21 cases): pipe-buffer deadlocks in both directions, SIGPIPE survival, backgrounded-child return, timed-out pipeline return, SIGTERM-ignoring command force kill, crash vs timeout, output cap, lossy decode, stream separation and merge, env, exit codes, timeout wording (avoids the ResultView provider-error heuristic). Full suite: 76 cases, all passing.

## Known out of scope

`ChainExecutor.runAppleShortcut` and `AppleShortcutsService.list()` still use the old read-after-exit pattern; routing them through `ShellRunner` is queued as a follow-up so this diff stays single-purpose.