### PR TITLE
feat: named secrets that shell commands use but the model never sees

### DIFF
--- a/Cai/Cai/Services/ChainExecutor.swift
+++ b/Cai/Cai/Services/ChainExecutor.swift
@@ -525,15 +525,18 @@ final class ChainExecutor {
     // MARK: - Shell shortcut runner
 
     private func runShell(template: String, input: String, sourceBundleId: String?) async throws -> String {
+        // Secrets travel in the environment, never in the command line.
+        let secrets = try SecretStore.prepareForShell(template: template)
         let resolved = try await TemplateEngine.render(
             template,
             vars: ["result": input],
             context: .shell,
-            sourceBundleId: sourceBundleId
+            sourceBundleId: sourceBundleId,
+            secrets: secrets.access
         )
 
         // Stdin = pipe value (so users can `cat`-style consume it in their command).
-        let output = try await ShellRunner.run(resolved, stdin: input)
+        let output = try await ShellRunner.run(resolved, stdin: input, environment: secrets.environment)
 
         if output.timedOut {
             throw ShellRunner.timeoutError()
@@ -541,11 +544,13 @@ final class ChainExecutor {
 
         guard output.status == 0 else {
             throw NSError(domain: "Cai", code: Int(output.status), userInfo: [
-                NSLocalizedDescriptionKey: output.failureMessage
+                NSLocalizedDescriptionKey: Redactor.redact(output.failureMessage, using: secrets.values)
             ])
         }
 
-        return output.trimmedStdout
+        // A command can print its own environment, and this value continues down
+        // the chain into other actions and the user's clipboard.
+        return Redactor.redact(output.trimmedStdout, using: secrets.values)
     }
 
     // MARK: - Prompt shortcut runner

--- a/Cai/Cai/Services/OutputDestinationService.swift
+++ b/Cai/Cai/Services/OutputDestinationService.swift
@@ -221,21 +221,32 @@ actor OutputDestinationService {
     private func executeShell(_ command: String, text: String, fields: [SetupField], sourceBundleId: String?) async throws {
         // .shell context applies |shell by default to bare {{result}} (single-quote
         // wrap + escape). Same output as the v1 escapeForShell pre-escape produced.
+        // Secrets travel in the environment, never in the command line.
+        let secrets = try SecretStore.prepareForShell(template: command)
         let resolved = try await render(
             command, text: text, fields: fields,
-            context: .shell, sourceBundleId: sourceBundleId
+            context: .shell, sourceBundleId: sourceBundleId,
+            secrets: secrets.access
         )
 
         // stderr is merged into stdout here, unlike the action paths: a failing
         // destination reports one combined stream to the user.
-        let output = try await ShellRunner.run(resolved, stdin: text, mergeStderrIntoStdout: true)
+        let output = try await ShellRunner.run(
+            resolved,
+            stdin: text,
+            environment: secrets.environment,
+            mergeStderrIntoStdout: true
+        )
 
         if output.timedOut {
             throw OutputDestinationError.timeout
         }
 
         guard output.status == 0 else {
-            throw OutputDestinationError.shellFailed(Int(output.status), output.stdout)
+            throw OutputDestinationError.shellFailed(
+                Int(output.status),
+                Redactor.redact(output.stdout, using: secrets.values)
+            )
         }
     }
 
@@ -298,17 +309,22 @@ actor OutputDestinationService {
         text: String,
         fields: [SetupField],
         context: TemplateEngine.Context,
-        sourceBundleId: String?
+        sourceBundleId: String?,
+        secrets: TemplateEngine.SecretAccess? = nil
     ) async throws -> String {
         var vars: [String: String] = ["result": text]
         for field in fields {
             vars[field.key] = field.value
         }
+        // Defaults to nil, so every destination surface except shell refuses
+        // secrets until it is deliberately opted in. Webhook headers and bodies
+        // are the next ones to enable.
         return try await TemplateEngine.render(
             template,
             vars: vars,
             context: context,
-            sourceBundleId: sourceBundleId
+            sourceBundleId: sourceBundleId,
+            secrets: secrets
         )
     }
 

--- a/Cai/Cai/Services/Redactor.swift
+++ b/Cai/Cai/Services/Redactor.swift
@@ -1,0 +1,43 @@
+import Foundation
+
+/// Removes secret values from text that is about to be shown, logged, or kept.
+///
+/// The last line of defence, not the first. Secrets reach a shell command through
+/// the environment and a webhook through a header, so they should never appear in
+/// output at all. But `webhookFailed(Int, String)` carries a response body,
+/// servers echo request material back, and a command can print its own
+/// environment. Anything on that path gets redacted before it becomes an alert,
+/// a log line, or a pinned clipboard entry that is written to disk.
+enum Redactor {
+
+    static let placeholder = "<redacted>"
+
+    /// Replaces every occurrence of every secret value.
+    ///
+    /// Longest first, so a secret that contains another (a token and its prefix)
+    /// cannot leave a fragment of the longer one behind. Values shorter than 4
+    /// characters are skipped: redacting those would blank out ordinary text
+    /// wherever they coincide, which hides the error the user needs to read
+    /// without protecting anything worth protecting.
+    static func redact(_ text: String, using secrets: [SecretValue]) -> String {
+        guard !text.isEmpty else { return text }
+
+        let values = secrets
+            .map(\.raw)
+            .filter { $0.count >= minimumRedactableLength }
+            .sorted { $0.count > $1.count }
+
+        var output = text
+        for value in values {
+            output = output.replacingOccurrences(of: value, with: placeholder)
+        }
+        return output
+    }
+
+    static func redact(_ text: String, using secrets: [String: SecretValue]) -> String {
+        redact(text, using: Array(secrets.values))
+    }
+
+    /// Below this, a "secret" is too short to distinguish from ordinary text.
+    static let minimumRedactableLength = 4
+}

--- a/Cai/Cai/Services/SecretStore.swift
+++ b/Cai/Cai/Services/SecretStore.swift
@@ -81,10 +81,18 @@ enum SecretStore {
         list().contains { $0.name == name }
     }
 
-    /// The value, for the moment of execution. Callers hold it no longer than
-    /// the command that needs it.
-    static func value(for name: String) -> SecretValue? {
-        guard SecretReference.isValidName(name) else { return nil }
+    enum LookupResult: Equatable {
+        case found(SecretValue)
+        case missing
+        /// The Keychain refused the query (locked at wake, ACL mismatch after a
+        /// re-sign, ...). Not the same as missing: telling the user to re-add a
+        /// secret that exists invites them to overwrite it.
+        case unavailable(OSStatus)
+    }
+
+    /// One name against the Keychain, with the failure mode preserved.
+    static func lookup(_ name: String) -> LookupResult {
+        guard SecretReference.isValidName(name) else { return .missing }
 
         let query: [String: Any] = [
             kSecClass as String: kSecClassGenericPassword,
@@ -95,27 +103,45 @@ enum SecretStore {
         ]
 
         var result: AnyObject?
-        guard SecItemCopyMatching(query as CFDictionary, &result) == errSecSuccess,
-              let data = result as? Data,
-              let string = String(data: data, encoding: .utf8) else {
-            return nil
+        let status = SecItemCopyMatching(query as CFDictionary, &result)
+        switch status {
+        case errSecSuccess:
+            guard let data = result as? Data,
+                  let string = String(data: data, encoding: .utf8) else {
+                return .unavailable(errSecDecode)
+            }
+            return .found(SecretValue(string))
+        case errSecItemNotFound:
+            return .missing
+        default:
+            return .unavailable(status)
         }
-        return SecretValue(string)
     }
 
-    /// Resolves what a template asked for. Missing names come back in
-    /// `missing` so the caller can name them rather than substituting nothing.
-    static func resolve(_ names: Set<String>) -> (found: [String: SecretValue], missing: Set<String>) {
+    /// The value, for the moment of execution. Callers hold it no longer than
+    /// the command that needs it.
+    static func value(for name: String) -> SecretValue? {
+        if case .found(let value) = lookup(name) { return value }
+        return nil
+    }
+
+    /// Resolves what a template asked for, or throws the error the user should
+    /// actually read: `unknownSecret` names the first missing secret rather
+    /// than substituting nothing, and a refusing Keychain is reported as
+    /// unavailable, never as "no such secret".
+    static func resolve(_ names: Set<String>) throws -> [String: SecretValue] {
         var found: [String: SecretValue] = [:]
-        var missing: Set<String> = []
-        for name in names {
-            if let value = value(for: name) {
+        for name in names.sorted() {
+            switch lookup(name) {
+            case .found(let value):
                 found[name] = value
-            } else {
-                missing.insert(name)
+            case .missing:
+                throw TemplateEngine.FilterError.unknownSecret(name: name)
+            case .unavailable(let status):
+                throw TemplateEngine.FilterError.keychainUnavailable(status: status)
             }
         }
-        return (found, missing)
+        return found
     }
 
     // MARK: - Writing
@@ -135,6 +161,11 @@ enum SecretStore {
         if let rejection = SecretReference.nameRejection(name) {
             return .invalidName(rejection)
         }
+        // Pasted tokens routinely arrive with a trailing newline (pbcopy,
+        // terminal copies). Stored verbatim it would both break auth and defeat
+        // redaction, since echoed output carries the token without the newline.
+        // Interior whitespace stays: PEM-style material is legitimate.
+        let value = value.trimmingCharacters(in: .whitespacesAndNewlines)
         guard let data = value.data(using: .utf8) else {
             return .invalidName("That value cannot be stored as text.")
         }
@@ -180,15 +211,15 @@ enum SecretStore {
     /// command that runs with an empty credential fails somewhere far away, and
     /// the user reads the wrong error.
     static func prepareForShell(template: String) throws -> ShellPreparation {
-        let referenced = SecretReference.names(in: template)
+        // The engine's own parse, not the package scanner: the quote-blind
+        // scanner may over-report on `}}` inside quoted filter args, and a
+        // secret must never be handed to a command that does not reference it.
+        let referenced = TemplateEngine.secretNames(in: template)
         guard !referenced.isEmpty else {
             return ShellPreparation(access: nil, environment: nil, values: [])
         }
 
-        let (found, missing) = resolve(referenced)
-        if let name = missing.sorted().first {
-            throw TemplateEngine.FilterError.unknownSecret(name: name)
-        }
+        let found = try resolve(referenced)
 
         var environment = OutputDestinationService.shellEnvironment()
         for (name, secret) in found {
@@ -196,7 +227,7 @@ enum SecretStore {
         }
 
         return ShellPreparation(
-            access: .environmentReference(found),
+            access: TemplateEngine.SecretAccess(values: found),
             environment: environment,
             values: Array(found.values)
         )

--- a/Cai/Cai/Services/SecretStore.swift
+++ b/Cai/Cai/Services/SecretStore.swift
@@ -1,0 +1,217 @@
+import CaiActionCore
+import Foundation
+import Security
+
+/// A secret's value, wrapped so it cannot be logged by accident.
+///
+/// `description` and `debugDescription` both return `<redacted>`, which covers
+/// string interpolation, `print`, `String(describing:)`, `%@` formatting and
+/// Sentry breadcrumbs built from any of those. Reaching the real characters
+/// takes `.raw`, which is greppable in review. That turns CAI-07 from a rule
+/// people have to remember into one the type enforces.
+struct SecretValue: CustomStringConvertible, CustomDebugStringConvertible, Equatable, Sendable {
+    let raw: String
+
+    init(_ raw: String) {
+        self.raw = raw
+    }
+
+    var description: String { "<redacted>" }
+    var debugDescription: String { "<redacted>" }
+}
+
+/// What the Secrets list shows about a stored secret. Never its value.
+struct SecretDescriptor: Identifiable, Equatable {
+    var id: String { name }
+    let name: String
+    let created: Date?
+    let modified: Date?
+}
+
+/// Named secrets in the Keychain.
+///
+/// **The Keychain is the list.** `SecItemCopyMatching` with `kSecMatchLimitAll`
+/// and `kSecReturnAttributes` enumerates the accounts under Cai's service with
+/// their creation dates and without their values, so there is no registry in
+/// UserDefaults to migrate, keep in sync, or leave orphaned when an item is
+/// deleted from Keychain Access.
+///
+/// Same service and same posture as the model API keys in `KeychainHelper`: the
+/// login keychain, no `kSecAttrSynchronizable` so nothing reaches iCloud, and no
+/// per-item ACL, because an ACL prompt from a menu-bar app in the middle of an
+/// Option+C action is worse than the flat posture. Hardening beyond that is a
+/// migration covering every item, not this feature.
+enum SecretStore {
+
+    private static let service = Bundle.main.bundleIdentifier ?? "com.soyasis.cai"
+
+    // MARK: - Reading
+
+    /// Every stored secret, name and dates only, sorted by name.
+    static func list() -> [SecretDescriptor] {
+        let query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: service,
+            kSecMatchLimit as String: kSecMatchLimitAll,
+            kSecReturnAttributes as String: true,
+            kSecReturnData as String: false,
+        ]
+
+        var result: AnyObject?
+        guard SecItemCopyMatching(query as CFDictionary, &result) == errSecSuccess,
+              let items = result as? [[String: Any]] else {
+            return []
+        }
+
+        return items.compactMap { attributes -> SecretDescriptor? in
+            guard let account = attributes[kSecAttrAccount as String] as? String,
+                  let name = SecretReference.name(fromAccount: account) else {
+                return nil  // the model API keys share this service
+            }
+            return SecretDescriptor(
+                name: name,
+                created: attributes[kSecAttrCreationDate as String] as? Date,
+                modified: attributes[kSecAttrModificationDate as String] as? Date
+            )
+        }
+        .sorted { $0.name < $1.name }
+    }
+
+    static func exists(_ name: String) -> Bool {
+        list().contains { $0.name == name }
+    }
+
+    /// The value, for the moment of execution. Callers hold it no longer than
+    /// the command that needs it.
+    static func value(for name: String) -> SecretValue? {
+        guard SecretReference.isValidName(name) else { return nil }
+
+        let query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: service,
+            kSecAttrAccount as String: SecretReference.accountName(for: name),
+            kSecReturnData as String: true,
+            kSecMatchLimit as String: kSecMatchLimitOne,
+        ]
+
+        var result: AnyObject?
+        guard SecItemCopyMatching(query as CFDictionary, &result) == errSecSuccess,
+              let data = result as? Data,
+              let string = String(data: data, encoding: .utf8) else {
+            return nil
+        }
+        return SecretValue(string)
+    }
+
+    /// Resolves what a template asked for. Missing names come back in
+    /// `missing` so the caller can name them rather than substituting nothing.
+    static func resolve(_ names: Set<String>) -> (found: [String: SecretValue], missing: Set<String>) {
+        var found: [String: SecretValue] = [:]
+        var missing: Set<String> = []
+        for name in names {
+            if let value = value(for: name) {
+                found[name] = value
+            } else {
+                missing.insert(name)
+            }
+        }
+        return (found, missing)
+    }
+
+    // MARK: - Writing
+
+    enum SaveResult: Equatable {
+        case saved
+        case replaced
+        case invalidName(String)
+        case keychainFailed(OSStatus)
+    }
+
+    /// Creates or overwrites. Overwriting is how a secret is rotated: forcing
+    /// delete-then-create would break every action referencing the name in
+    /// between, and buys nothing, since whoever can overwrite can also delete.
+    @discardableResult
+    static func save(_ value: String, name: String) -> SaveResult {
+        if let rejection = SecretReference.nameRejection(name) {
+            return .invalidName(rejection)
+        }
+        guard let data = value.data(using: .utf8) else {
+            return .invalidName("That value cannot be stored as text.")
+        }
+
+        let query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: service,
+            kSecAttrAccount as String: SecretReference.accountName(for: name),
+        ]
+
+        let update = SecItemUpdate(query as CFDictionary, [kSecValueData as String: data] as CFDictionary)
+        if update == errSecSuccess { return .replaced }
+        guard update == errSecItemNotFound else { return .keychainFailed(update) }
+
+        var item = query
+        item[kSecValueData as String] = data
+        let add = SecItemAdd(item as CFDictionary, nil)
+        return add == errSecSuccess ? .saved : .keychainFailed(add)
+    }
+
+    // MARK: - Preparing a shell command
+
+    /// Everything a shell call site needs to run a template that may reference
+    /// secrets: what the engine is allowed to do, the environment the values
+    /// travel in, and the values themselves for redacting output afterwards.
+    struct ShellPreparation {
+        /// nil when the template references no secret, which keeps templates
+        /// without secrets on exactly the path they were on before.
+        let access: TemplateEngine.SecretAccess?
+        /// nil means "runner default". Non-nil carries `CAI_SECRET_*` on top of
+        /// the usual shell environment.
+        let environment: [String: String]?
+        /// For `Redactor`, in case the command prints a value back.
+        let values: [SecretValue]
+
+        var isEmpty: Bool { access == nil }
+    }
+
+    /// One place all three shell call sites go through, so the environment
+    /// cannot be wired into some of them and forgotten in the others.
+    ///
+    /// Throws `unknownSecret` rather than resolving a missing name to nothing: a
+    /// command that runs with an empty credential fails somewhere far away, and
+    /// the user reads the wrong error.
+    static func prepareForShell(template: String) throws -> ShellPreparation {
+        let referenced = SecretReference.names(in: template)
+        guard !referenced.isEmpty else {
+            return ShellPreparation(access: nil, environment: nil, values: [])
+        }
+
+        let (found, missing) = resolve(referenced)
+        if let name = missing.sorted().first {
+            throw TemplateEngine.FilterError.unknownSecret(name: name)
+        }
+
+        var environment = OutputDestinationService.shellEnvironment()
+        for (name, secret) in found {
+            environment[SecretReference.environmentVariable(for: name)] = secret.raw
+        }
+
+        return ShellPreparation(
+            access: .environmentReference(found),
+            environment: environment,
+            values: Array(found.values)
+        )
+    }
+
+    @discardableResult
+    static func delete(_ name: String) -> Bool {
+        guard SecretReference.isValidName(name) else { return false }
+
+        let query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: service,
+            kSecAttrAccount as String: SecretReference.accountName(for: name),
+        ]
+        let status = SecItemDelete(query as CFDictionary)
+        return status == errSecSuccess || status == errSecItemNotFound
+    }
+}

--- a/Cai/Cai/Services/TemplateEngine.swift
+++ b/Cai/Cai/Services/TemplateEngine.swift
@@ -32,7 +32,7 @@ struct TemplateEngine {
         case raw
     }
 
-    /// What a call site may do with `{{SECRET_NAME}}` references.
+    /// Permission for a call site to resolve `{{secrets.NAME}}` references.
     ///
     /// **This is a property of the destination, not of `Context`.** `Context`
     /// selects an escaping filter, and two very different sinks share
@@ -40,22 +40,19 @@ struct TemplateEngine {
     /// prompts, whose rendered output goes verbatim to a model. So the call site
     /// has to say, and the safe answer is the default: passing `nil` refuses.
     ///
+    /// The only grant that exists is the shell one: the rendered command gets
+    /// `"$CAI_SECRET_NAME"` and the value travels in the process environment, so
+    /// it never appears in the rendered string that reaches the result UI,
+    /// history, or process listings visible to other users. (A same-uid process
+    /// can still read a child's environment; env narrows exposure, it does not
+    /// erase it.) Webhook substitution is a future grant, deliberately not
+    /// shipped unused so it can land fail-closed with its call site.
+    ///
     /// Refusal throws rather than resolving to empty. An action that appears to
     /// work while sending no credential is the failure people ship.
-    enum SecretAccess {
-        /// The value is substituted into the output. Webhook headers and bodies.
-        case substituted([String: SecretValue])
-        /// The output gets `"$CAI_SECRET_NAME"` and the value is handed to the
-        /// process environment instead, so it never enters `argv` where any
-        /// same-user process could read it from `ps`. Shell commands.
-        case environmentReference([String: SecretValue])
-
-        var values: [String: SecretValue] {
-            switch self {
-            case .substituted(let values), .environmentReference(let values):
-                return values
-            }
-        }
+    struct SecretAccess {
+        /// The resolved values, for reference lookup and post-run redaction.
+        let values: [String: SecretValue]
     }
 
     /// Errors thrown during template parsing or filter execution.
@@ -71,6 +68,13 @@ struct TemplateEngine {
         case unknownSecret(name: String)
         /// A filter that would move a secret somewhere it must not go.
         case secretThroughFilter(name: String, filter: String)
+        /// The Keychain refused the lookup (locked, denied). Distinct from
+        /// `unknownSecret`: telling the user to re-add a secret that exists
+        /// invites them to overwrite it.
+        case keychainUnavailable(status: OSStatus)
+        /// The reference sits inside single quotes, where the shell would send
+        /// the literal `$CAI_SECRET_*` text as the credential.
+        case secretInSingleQuotes(name: String)
 
         var errorDescription: String? {
             switch self {
@@ -85,11 +89,15 @@ struct TemplateEngine {
             case .busy:
                 return "Cai is busy. Try again in a moment."
             case .secretNotAllowed(let name):
-                return "{{\(name)}} can't be used here. Secrets work in shell commands and webhooks, not in prompts, because a prompt is sent to the model."
+                return "{{secrets.\(name)}} can't be used here. Secrets work only in shell commands for now."
             case .unknownSecret(let name):
-                return "No secret named \(name). Add it in Settings → Secrets."
+                return "No secret named \(name) is stored on this Mac."
             case .secretThroughFilter(let name, let filter):
-                return "{{\(name)}} can't go through |\(filter). A secret would be sent to the model."
+                return "{{secrets.\(name)}} can't go through |\(filter). Filters could move the value somewhere Cai can't protect."
+            case .keychainUnavailable(let status):
+                return "Cai couldn't read your secrets from the Keychain (error \(status)). Unlock the login keychain and try again."
+            case .secretInSingleQuotes(let name):
+                return "{{secrets.\(name)}} is inside single quotes, so the shell would send the literal text instead of the secret. Put it in double quotes."
             }
         }
     }
@@ -127,15 +135,29 @@ struct TemplateEngine {
             case .literal(let text):
                 output += text
             case .placeholder(let varName, let filters)
-                where SecretReference.isValidName(varName):
-                // Upper-case placeholders are secret references, and every sink
-                // that has not opted in refuses them. See `SecretAccess`.
-                output += try await resolveSecret(
-                    named: varName,
+                where SecretReference.claimsNamespace(varName):
+                // `secrets.*` placeholders are secret references, and every sink
+                // that has not opted in refuses them. See `SecretAccess`. A
+                // broken name inside the namespace is loud, unlike ordinary
+                // unknown variables: nobody decorates a template with
+                // `{{secrets.…}}` by accident.
+                guard let name = SecretReference.name(fromReference: varName) else {
+                    throw FilterError.parseError(
+                        "{{\(varName)}} is not a valid secret reference. Names look like secrets.NOTION_API_TOKEN."
+                    )
+                }
+                let reference = try resolveSecret(
+                    named: name,
                     filterNames: filters.map(\.name),
-                    access: secrets,
-                    context: context
+                    access: secrets
                 )
+                // zsh expands nothing inside single quotes; the literal
+                // reference would be sent as the credential. Refuse rather
+                // than misfire silently.
+                if context == .shell, endsInsideSingleQuote(output) {
+                    throw FilterError.secretInSingleQuotes(name: name)
+                }
+                output += reference
             case .placeholder(let varName, let filters):
                 // Unknown variable → empty string. We don't throw here because copying
                 // templates between contexts (e.g. {{title}} in a shell shortcut) is
@@ -173,67 +195,90 @@ struct TemplateEngine {
 
     // MARK: - Secrets
 
-    /// Filters a secret may pass through. An allowlist, because the question is
-    /// not "which filters are dangerous" but "which are known to keep the value
-    /// where it is going". `|llm` is the one that matters: it would send the
-    /// secret to the model, which is the entire thing this design prevents.
+    /// Filters that are not refused hard on a secret reference. `|raw` is
+    /// accepted as a no-op, since an environment reference is never escaped,
+    /// which is exactly what `|raw` asks for. `|json` and `|url_encode` are
+    /// refused gently (they cannot apply to a value that never enters the
+    /// output). Anything else — above all `|llm` — is refused hard: it would
+    /// move the value somewhere it must not go, which is the entire thing this
+    /// design prevents.
     static let filtersAllowedOnSecrets: Set<String> = ["json", "url_encode", "raw"]
 
-    /// Resolves one `{{SECRET_NAME}}` placeholder, or throws.
+    /// Resolves one `{{secrets.NAME}}` placeholder to its environment
+    /// reference, or throws.
     ///
     /// Takes its values as an argument rather than reading the Keychain, so the
-    /// whole policy is covered by `SecretPolicyTests` without a live store.
+    /// whole policy is covered by `SecretPolicyTests` without a live store. The
+    /// value itself never enters the rendered command: the returned reference is
+    /// double-quoted so a secret containing spaces stays one word, and the shell
+    /// expands it after we are done.
     static func resolveSecret(
         named name: String,
         filterNames: [String],
-        access: SecretAccess?,
-        context: Context
-    ) async throws -> String {
+        access: SecretAccess?
+    ) throws -> String {
         guard let access else {
             throw FilterError.secretNotAllowed(name: name)
         }
-        guard let secret = access.values[name] else {
+        guard access.values[name] != nil else {
             throw FilterError.unknownSecret(name: name)
         }
 
         if let offending = filterNames.first(where: { !filtersAllowedOnSecrets.contains($0) }) {
             throw FilterError.secretThroughFilter(name: name, filter: offending)
         }
-
-        switch access {
-        case .environmentReference:
-            // The value never enters the rendered command. Double-quoted so a
-            // secret containing spaces stays one word, and no escaping filter is
-            // applied, since the shell expands this after we are done.
-            guard filterNames.isEmpty else {
-                throw FilterError.badArgument(
-                    "a secret in a shell command is passed through the environment, so filters do not apply to it",
-                    filter: filterNames[0]
-                )
-            }
-            return "\"$\(SecretReference.environmentVariable(for: name))\""
-
-        case .substituted:
-            var value = secret.raw
-            var chain = filterNames.map { FilterCall(name: $0, args: []) }
-            // Same safe-by-default rule as ordinary variables: end in the
-            // context's escape unless the author opted out with |raw.
-            if let safety = safetyFilter(for: context),
-               filtersAllowedOnSecrets.contains(safety),
-               chain.last?.name != "raw", chain.last?.name != safety {
-                chain.append(FilterCall(name: safety, args: []))
-            }
-            for call in chain {
-                guard let filter = filterRegistry[call.name] else {
-                    throw FilterError.unknownFilter(call.name)
-                }
-                // `sourceBundleId` is deliberately not forwarded: it exists to
-                // give `|llm` its Context Snippet, and no filter reachable from
-                // here talks to a model.
-                value = try await filter.apply(value, args: call.args, sourceBundleId: nil)
-            }
-            return value
+        if let inapplicable = filterNames.first(where: { $0 != "raw" }) {
+            throw FilterError.badArgument(
+                "a secret in a shell command is passed through the environment, so escaping filters do not apply to it",
+                filter: inapplicable
+            )
         }
+
+        return "\"$\(SecretReference.environmentVariable(for: name))\""
+    }
+
+    /// The secret names a template resolves, per the engine's own parser.
+    ///
+    /// This is what `SecretStore.prepareForShell` uses, so execution can never
+    /// disagree with rendering about which secrets a command needs. (The
+    /// quote-blind scanner in `SecretReference` may over-report on templates
+    /// with `}}` inside quoted filter args; it serves only the validator's
+    /// advisory question.) Malformed templates return empty and leave the parse
+    /// error to `render`, where it is thrown with context.
+    static func secretNames(in template: String) -> Set<String> {
+        guard let segments = try? parse(template) else { return [] }
+        var found: Set<String> = []
+        for case .placeholder(let varName, _) in segments {
+            if let name = SecretReference.name(fromReference: varName) {
+                found.insert(name)
+            }
+        }
+        return found
+    }
+
+    /// Whether a rendered shell-command prefix ends inside an unclosed single
+    /// quote. zsh expands nothing there, so an environment reference emitted at
+    /// that position would send literal text as the credential. Backslash
+    /// escapes the next character except inside single quotes, which is zsh's
+    /// rule.
+    static func endsInsideSingleQuote(_ prefix: String) -> Bool {
+        var quote: Character? = nil
+        var escaped = false
+        for character in prefix {
+            if escaped {
+                escaped = false
+                continue
+            }
+            switch quote {
+            case "'":
+                if character == "'" { quote = nil }
+            case "\"":
+                if character == "\\" { escaped = true } else if character == "\"" { quote = nil }
+            default:
+                if character == "\\" { escaped = true } else if character == "'" || character == "\"" { quote = character }
+            }
+        }
+        return quote == "'"
     }
 
     // MARK: - Default Filter per Context

--- a/Cai/Cai/Services/TemplateEngine.swift
+++ b/Cai/Cai/Services/TemplateEngine.swift
@@ -1,3 +1,4 @@
+import CaiActionCore
 import Foundation
 
 // MARK: - Template Engine
@@ -31,6 +32,32 @@ struct TemplateEngine {
         case raw
     }
 
+    /// What a call site may do with `{{SECRET_NAME}}` references.
+    ///
+    /// **This is a property of the destination, not of `Context`.** `Context`
+    /// selects an escaping filter, and two very different sinks share
+    /// `Context.raw`: webhook headers, where a token is the whole point, and LLM
+    /// prompts, whose rendered output goes verbatim to a model. So the call site
+    /// has to say, and the safe answer is the default: passing `nil` refuses.
+    ///
+    /// Refusal throws rather than resolving to empty. An action that appears to
+    /// work while sending no credential is the failure people ship.
+    enum SecretAccess {
+        /// The value is substituted into the output. Webhook headers and bodies.
+        case substituted([String: SecretValue])
+        /// The output gets `"$CAI_SECRET_NAME"` and the value is handed to the
+        /// process environment instead, so it never enters `argv` where any
+        /// same-user process could read it from `ps`. Shell commands.
+        case environmentReference([String: SecretValue])
+
+        var values: [String: SecretValue] {
+            switch self {
+            case .substituted(let values), .environmentReference(let values):
+                return values
+            }
+        }
+    }
+
     /// Errors thrown during template parsing or filter execution.
     enum FilterError: Error, LocalizedError {
         case parseError(String)
@@ -38,6 +65,12 @@ struct TemplateEngine {
         case badArgument(String, filter: String)
         case llmFailed(String)
         case busy
+        /// The template reaches for a secret in a place secrets may not go.
+        case secretNotAllowed(name: String)
+        /// The template reaches for a secret that does not exist.
+        case unknownSecret(name: String)
+        /// A filter that would move a secret somewhere it must not go.
+        case secretThroughFilter(name: String, filter: String)
 
         var errorDescription: String? {
             switch self {
@@ -51,6 +84,12 @@ struct TemplateEngine {
                 return "LLM filter failed: \(detail)"
             case .busy:
                 return "Cai is busy. Try again in a moment."
+            case .secretNotAllowed(let name):
+                return "{{\(name)}} can't be used here. Secrets work in shell commands and webhooks, not in prompts, because a prompt is sent to the model."
+            case .unknownSecret(let name):
+                return "No secret named \(name). Add it in Settings → Secrets."
+            case .secretThroughFilter(let name, let filter):
+                return "{{\(name)}} can't go through |\(filter). A secret would be sent to the model."
             }
         }
     }
@@ -78,7 +117,8 @@ struct TemplateEngine {
         _ template: String,
         vars: [String: String],
         context: Context,
-        sourceBundleId: String? = nil
+        sourceBundleId: String? = nil,
+        secrets: SecretAccess? = nil
     ) async throws -> String {
         let segments = try parse(template)
         var output = ""
@@ -86,6 +126,16 @@ struct TemplateEngine {
             switch segment {
             case .literal(let text):
                 output += text
+            case .placeholder(let varName, let filters)
+                where SecretReference.isValidName(varName):
+                // Upper-case placeholders are secret references, and every sink
+                // that has not opted in refuses them. See `SecretAccess`.
+                output += try await resolveSecret(
+                    named: varName,
+                    filterNames: filters.map(\.name),
+                    access: secrets,
+                    context: context
+                )
             case .placeholder(let varName, let filters):
                 // Unknown variable → empty string. We don't throw here because copying
                 // templates between contexts (e.g. {{title}} in a shell shortcut) is
@@ -119,6 +169,71 @@ struct TemplateEngine {
             }
         }
         return output
+    }
+
+    // MARK: - Secrets
+
+    /// Filters a secret may pass through. An allowlist, because the question is
+    /// not "which filters are dangerous" but "which are known to keep the value
+    /// where it is going". `|llm` is the one that matters: it would send the
+    /// secret to the model, which is the entire thing this design prevents.
+    static let filtersAllowedOnSecrets: Set<String> = ["json", "url_encode", "raw"]
+
+    /// Resolves one `{{SECRET_NAME}}` placeholder, or throws.
+    ///
+    /// Takes its values as an argument rather than reading the Keychain, so the
+    /// whole policy is covered by `SecretPolicyTests` without a live store.
+    static func resolveSecret(
+        named name: String,
+        filterNames: [String],
+        access: SecretAccess?,
+        context: Context
+    ) async throws -> String {
+        guard let access else {
+            throw FilterError.secretNotAllowed(name: name)
+        }
+        guard let secret = access.values[name] else {
+            throw FilterError.unknownSecret(name: name)
+        }
+
+        if let offending = filterNames.first(where: { !filtersAllowedOnSecrets.contains($0) }) {
+            throw FilterError.secretThroughFilter(name: name, filter: offending)
+        }
+
+        switch access {
+        case .environmentReference:
+            // The value never enters the rendered command. Double-quoted so a
+            // secret containing spaces stays one word, and no escaping filter is
+            // applied, since the shell expands this after we are done.
+            guard filterNames.isEmpty else {
+                throw FilterError.badArgument(
+                    "a secret in a shell command is passed through the environment, so filters do not apply to it",
+                    filter: filterNames[0]
+                )
+            }
+            return "\"$\(SecretReference.environmentVariable(for: name))\""
+
+        case .substituted:
+            var value = secret.raw
+            var chain = filterNames.map { FilterCall(name: $0, args: []) }
+            // Same safe-by-default rule as ordinary variables: end in the
+            // context's escape unless the author opted out with |raw.
+            if let safety = safetyFilter(for: context),
+               filtersAllowedOnSecrets.contains(safety),
+               chain.last?.name != "raw", chain.last?.name != safety {
+                chain.append(FilterCall(name: safety, args: []))
+            }
+            for call in chain {
+                guard let filter = filterRegistry[call.name] else {
+                    throw FilterError.unknownFilter(call.name)
+                }
+                // `sourceBundleId` is deliberately not forwarded: it exists to
+                // give `|llm` its Context Snippet, and no filter reachable from
+                // here talks to a model.
+                value = try await filter.apply(value, args: call.args, sourceBundleId: nil)
+            }
+            return value
+        }
     }
 
     // MARK: - Default Filter per Context

--- a/Cai/Cai/Views/ActionListWindow.swift
+++ b/Cai/Cai/Views/ActionListWindow.swift
@@ -1934,16 +1934,19 @@ struct ActionListWindow: View {
     /// is forwarded so any `|llm` filters in the template inherit the source app's
     /// Context Snippet.
     private static func runShellCommand(_ template: String, text: String, sourceBundleId: String?) async throws -> String {
+        // Secrets travel in the environment, never in the command line.
+        let secrets = try SecretStore.prepareForShell(template: template)
         let resolved = try await TemplateEngine.render(
             template,
             vars: ["result": text],
             context: .shell,
-            sourceBundleId: sourceBundleId
+            sourceBundleId: sourceBundleId,
+            secrets: secrets.access
         )
 
         // Text goes in as stdin. The runner supplies the Homebrew PATH that
         // non-interactive zsh lacks.
-        let output = try await ShellRunner.run(resolved, stdin: text)
+        let output = try await ShellRunner.run(resolved, stdin: text, environment: secrets.environment)
 
         if output.timedOut {
             throw ShellRunner.timeoutError()
@@ -1951,10 +1954,12 @@ struct ActionListWindow: View {
 
         guard output.status == 0 else {
             throw NSError(domain: "Cai", code: Int(output.status), userInfo: [
-                NSLocalizedDescriptionKey: output.failureMessage
+                NSLocalizedDescriptionKey: Redactor.redact(output.failureMessage, using: secrets.values)
             ])
         }
 
-        return output.trimmedStdout
+        // A command can print its own environment, and this value lands on the
+        // user's clipboard.
+        return Redactor.redact(output.trimmedStdout, using: secrets.values)
     }
 }

--- a/Cai/CaiActionCore/Sources/CaiActionCore/SecretReference.swift
+++ b/Cai/CaiActionCore/Sources/CaiActionCore/SecretReference.swift
@@ -1,0 +1,110 @@
+import Foundation
+
+/// Named secrets as they appear inside an action: `{{NOTION_API_TOKEN}}`.
+///
+/// The action stores the reference; the value lives in the Keychain and is
+/// resolved at execution time. That is what lets an agent author an action that
+/// uses a token, and a user export or share one, without either seeing it.
+///
+/// **The name shape is what marks a placeholder as a secret reference.** Every
+/// other variable in Cai is lowercase (`result`, and the MCP form keys), so
+/// upper-case placeholders are unambiguous. Note what this does *not* mean:
+/// nothing is protected because of how it is named. A mistyped reference
+/// resolves to no secret and is refused, never stored or sent. That is the
+/// difference from Keyboard Maestro, where a variable is protected only if its
+/// name contains "password" and a typo silently writes the value to disk.
+public enum SecretReference {
+
+    /// Keychain account prefix. Sits under the same service as the model API
+    /// keys, so `cai_secret_` is what separates the two families.
+    public static let accountPrefix = "cai_secret_"
+
+    /// Environment variable prefix. A shell template's `{{NOTION_API_TOKEN}}`
+    /// renders as `"$CAI_SECRET_NOTION_API_TOKEN"` and the value arrives through
+    /// the process environment, so it never enters the command line.
+    public static let environmentPrefix = "CAI_SECRET_"
+
+    public static let maxNameLength = 64
+
+    // MARK: - Names
+
+    /// Upper-case, digits and underscores, starting with a letter, 2 to 64
+    /// characters.
+    ///
+    /// Hand-rolled rather than a regex so the rule is readable and cannot
+    /// surprise anyone with backtracking behaviour.
+    public static func isValidName(_ name: String) -> Bool {
+        guard name.count >= 2, name.count <= maxNameLength else { return false }
+        guard let first = name.first, first.isASCII, first.isUppercase else { return false }
+        return name.allSatisfy { character in
+            guard character.isASCII else { return false }
+            return character.isUppercase || character.isNumber || character == "_"
+        }
+    }
+
+    /// Why a name was rejected, phrased for the person typing it.
+    public static func nameRejection(_ name: String) -> String? {
+        if name.isEmpty { return "Give the secret a name." }
+        if name.count < 2 { return "Use at least two characters." }
+        if name.count > maxNameLength { return "Keep the name under \(maxNameLength) characters." }
+        if let first = name.first, !(first.isASCII && first.isUppercase) {
+            return "Start with an upper-case letter, like NOTION_API_TOKEN."
+        }
+        if !isValidName(name) {
+            return "Use upper-case letters, numbers and underscores only."
+        }
+        return nil
+    }
+
+    public static func accountName(for name: String) -> String {
+        accountPrefix + name
+    }
+
+    /// The secret name inside a Keychain account, or nil for accounts that
+    /// belong to something else (the model API keys share the service).
+    public static func name(fromAccount account: String) -> String? {
+        guard account.hasPrefix(accountPrefix) else { return nil }
+        let name = String(account.dropFirst(accountPrefix.count))
+        return isValidName(name) ? name : nil
+    }
+
+    public static func environmentVariable(for name: String) -> String {
+        environmentPrefix + name
+    }
+
+    // MARK: - Finding references in a template
+
+    /// Every secret name a template refers to.
+    ///
+    /// Deliberately a separate, stricter scanner than `TemplateEngine`'s parser:
+    /// this runs in the shared package so the validator can flag a proposed
+    /// action that reaches for a token, and it must not depend on the app. The
+    /// two agreeing matters, so `SecretReferenceAgreementTests` cross-checks
+    /// them against a corpus rather than trusting that they drift together.
+    ///
+    /// Filters are ignored here: `{{TOKEN|json}}` refers to `TOKEN`.
+    public static func names(in template: String) -> Set<String> {
+        var found: Set<String> = []
+        var remainder = Substring(template)
+
+        while let open = remainder.range(of: "{{") {
+            remainder = remainder[open.upperBound...]
+            guard let close = remainder.range(of: "}}") else { break }
+            let body = remainder[..<close.lowerBound]
+            remainder = remainder[close.upperBound...]
+
+            // The variable is everything before the first filter pipe.
+            let variable = body.prefix { $0 != "|" }.trimmingCharacters(in: .whitespaces)
+            if isValidName(variable) {
+                found.insert(variable)
+            }
+        }
+        return found
+    }
+
+    /// Whether a template refers to any secret at all. The question the
+    /// approval sheet asks.
+    public static func referencesAnySecret(_ template: String) -> Bool {
+        !names(in: template).isEmpty
+    }
+}

--- a/Cai/CaiActionCore/Sources/CaiActionCore/SecretReference.swift
+++ b/Cai/CaiActionCore/Sources/CaiActionCore/SecretReference.swift
@@ -1,27 +1,36 @@
 import Foundation
 
-/// Named secrets as they appear inside an action: `{{NOTION_API_TOKEN}}`.
+/// Named secrets as they appear inside an action: `{{secrets.NOTION_API_TOKEN}}`.
 ///
 /// The action stores the reference; the value lives in the Keychain and is
 /// resolved at execution time. That is what lets an agent author an action that
 /// uses a token, and a user export or share one, without either seeing it.
 ///
-/// **The name shape is what marks a placeholder as a secret reference.** Every
-/// other variable in Cai is lowercase (`result`, and the MCP form keys), so
-/// upper-case placeholders are unambiguous. Note what this does *not* mean:
-/// nothing is protected because of how it is named. A mistyped reference
-/// resolves to no secret and is refused, never stored or sent. That is the
-/// difference from Keyboard Maestro, where a variable is protected only if its
-/// name contains "password" and a typo silently writes the value to disk.
+/// **The `secrets.` namespace is what marks a placeholder as a secret
+/// reference.** Nothing else can collide with it: ordinary variables (`result`,
+/// setup-field keys, MCP form keys) have no such prefix, whatever their casing,
+/// so no existing template changes meaning. The spelling is GitHub Actions'
+/// (`secrets.NAME`), which is the one most users already know. Note what this
+/// does *not* mean: nothing is protected because of how it is named. A mistyped
+/// reference resolves to no secret and is refused, never stored or sent. That is
+/// the difference from Keyboard Maestro, where a variable is protected only if
+/// its name contains "password" and a typo silently writes the value to disk.
 public enum SecretReference {
+
+    /// Placeholder namespace. `{{secrets.NOTION_API_TOKEN}}` refers to the
+    /// secret named `NOTION_API_TOKEN`.
+    public static let referencePrefix = "secrets."
 
     /// Keychain account prefix. Sits under the same service as the model API
     /// keys, so `cai_secret_` is what separates the two families.
     public static let accountPrefix = "cai_secret_"
 
-    /// Environment variable prefix. A shell template's `{{NOTION_API_TOKEN}}`
-    /// renders as `"$CAI_SECRET_NOTION_API_TOKEN"` and the value arrives through
-    /// the process environment, so it never enters the command line.
+    /// Environment variable prefix. A shell template's
+    /// `{{secrets.NOTION_API_TOKEN}}` renders as
+    /// `"$CAI_SECRET_NOTION_API_TOKEN"` and the value arrives through the
+    /// process environment, so it never enters the command line. The name is the
+    /// env-var name on purpose: the planned fallback resolves a secret Cai does
+    /// not hold from the user's own shell environment, same name, no second copy.
     public static let environmentPrefix = "CAI_SECRET_"
 
     public static let maxNameLength = 64
@@ -29,7 +38,7 @@ public enum SecretReference {
     // MARK: - Names
 
     /// Upper-case, digits and underscores, starting with a letter, 2 to 64
-    /// characters.
+    /// characters. Env-var shape, because the name must survive as one.
     ///
     /// Hand-rolled rather than a regex so the rule is readable and cannot
     /// surprise anyone with backtracking behaviour.
@@ -56,6 +65,24 @@ public enum SecretReference {
         return nil
     }
 
+    /// The secret name inside a placeholder variable, or nil when the variable
+    /// is not in the `secrets.` namespace. `"secrets.NOTION_API_TOKEN"` →
+    /// `"NOTION_API_TOKEN"`; `"result"` → nil; `"secrets.bad-name"` → nil
+    /// (the caller decides whether that is an error, and for the engine it is:
+    /// reaching into the namespace with a broken name must be loud).
+    public static func name(fromReference variable: String) -> String? {
+        guard variable.hasPrefix(referencePrefix) else { return nil }
+        let name = String(variable.dropFirst(referencePrefix.count))
+        return isValidName(name) ? name : nil
+    }
+
+    /// Whether a placeholder variable claims the `secrets.` namespace at all,
+    /// valid name or not. What separates "not a secret" from "a secret
+    /// reference written wrong".
+    public static func claimsNamespace(_ variable: String) -> Bool {
+        variable.hasPrefix(referencePrefix)
+    }
+
     public static func accountName(for name: String) -> String {
         accountPrefix + name
     }
@@ -74,15 +101,21 @@ public enum SecretReference {
 
     // MARK: - Finding references in a template
 
-    /// Every secret name a template refers to.
+    /// Every secret name a template appears to refer to.
     ///
-    /// Deliberately a separate, stricter scanner than `TemplateEngine`'s parser:
-    /// this runs in the shared package so the validator can flag a proposed
-    /// action that reaches for a token, and it must not depend on the app. The
-    /// two agreeing matters, so `SecretReferenceAgreementTests` cross-checks
-    /// them against a corpus rather than trusting that they drift together.
+    /// This is the shared package's scanner, for the validator's question "does
+    /// this proposed action touch a secret?", where it must not depend on the
+    /// app. It is deliberately simpler than `TemplateEngine`'s quote-aware
+    /// parser, and the contract is **it may over-report but must never
+    /// under-report** relative to what the engine resolves: a false positive
+    /// makes a proposal look slightly scarier than it is; a false negative would
+    /// hide a credential from the approval sheet. The agreement test in
+    /// `SecretReferenceTests` pins that direction on a corpus, including the
+    /// quoted-`}}` templates where the two genuinely disagree. Execution never
+    /// trusts this scanner: `SecretStore.prepareForShell` takes its names from
+    /// the engine's own parse.
     ///
-    /// Filters are ignored here: `{{TOKEN|json}}` refers to `TOKEN`.
+    /// Filters are ignored here: `{{secrets.TOKEN|json}}` refers to `TOKEN`.
     public static func names(in template: String) -> Set<String> {
         var found: Set<String> = []
         var remainder = Substring(template)
@@ -95,15 +128,15 @@ public enum SecretReference {
 
             // The variable is everything before the first filter pipe.
             let variable = body.prefix { $0 != "|" }.trimmingCharacters(in: .whitespaces)
-            if isValidName(variable) {
-                found.insert(variable)
+            if let name = name(fromReference: variable) {
+                found.insert(name)
             }
         }
         return found
     }
 
     /// Whether a template refers to any secret at all. The question the
-    /// approval sheet asks.
+    /// approval sheet asks (wired in the secrets-ui PR).
     public static func referencesAnySecret(_ template: String) -> Bool {
         !names(in: template).isEmpty
     }

--- a/Cai/CaiTests/SecretEndToEndTests.swift
+++ b/Cai/CaiTests/SecretEndToEndTests.swift
@@ -1,0 +1,80 @@
+import XCTest
+import CaiActionCore
+@testable import Cai
+
+/// A real secret, through the real store, into a real command.
+///
+/// The unit tests pin each layer's decision in isolation; this is the one place
+/// they meet, and it pins the claim the feature actually makes to the user: the
+/// command can use the token, and the token is not in the command line. It is
+/// deliberately the only test here that spawns a real subprocess. Redaction and
+/// the sink policy are covered without one; this exists because nothing short of
+/// a real `zsh` proves the environment reference resolves to the value.
+final class SecretEndToEndTests: XCTestCase {
+
+    private let secretName = "ZZ_CAI_E2E_TOKEN"
+    private let value = "sk-live-e2e-9f8e7d6c"
+
+    override func setUp() {
+        super.setUp()
+        SecretStore.save(value, name: secretName)
+    }
+
+    override func tearDown() {
+        SecretStore.delete(secretName)
+        super.tearDown()
+    }
+
+    func testACommandCanUseTheSecretWithoutItEnteringTheCommandLine() async throws {
+        // Unquoted in the template: the engine supplies the quotes around the
+        // environment reference itself.
+        let template = "printf '%s' {{\(secretName)}}"
+
+        let prepared = try SecretStore.prepareForShell(template: template)
+        let rendered = try await TemplateEngine.render(
+            template,
+            vars: ["result": ""],
+            context: .shell,
+            secrets: prepared.access
+        )
+
+        // The rendered command is what would show up in `ps`.
+        XCTAssertFalse(rendered.contains(value), "the value entered argv: \(rendered)")
+        XCTAssertTrue(rendered.contains("$CAI_SECRET_\(secretName)"))
+
+        let output = try await ShellRunner.run(rendered, stdin: "", environment: prepared.environment)
+
+        XCTAssertEqual(output.status, 0)
+        XCTAssertEqual(output.trimmedStdout, value, "the command could not read the secret it was given")
+    }
+
+    func testAPromptStepRefusesTheSameSecret() async {
+        // The sink that matters. Same store, same name, same engine.
+        do {
+            _ = try await TemplateEngine.render(
+                "Summarize this using {{\(secretName)}}",
+                vars: ["result": "text"],
+                context: .raw,
+                secrets: nil
+            )
+            XCTFail("a prompt resolved a secret")
+        } catch TemplateEngine.FilterError.secretNotAllowed(let refused) {
+            XCTAssertEqual(refused, secretName)
+        } catch {
+            XCTFail("wrong error: \(error)")
+        }
+    }
+
+    func testTheEnvironmentCarriesOnlyTheSecretsTheTemplateAsksFor() throws {
+        SecretStore.save("other-value", name: "ZZ_CAI_E2E_OTHER")
+        defer { SecretStore.delete("ZZ_CAI_E2E_OTHER") }
+
+        let prepared = try SecretStore.prepareForShell(template: "echo {{\(secretName)}}")
+
+        XCTAssertNotNil(prepared.environment?["CAI_SECRET_\(secretName)"])
+        XCTAssertNil(
+            prepared.environment?["CAI_SECRET_ZZ_CAI_E2E_OTHER"],
+            "a command must not be handed credentials it never referenced"
+        )
+    }
+}

--- a/Cai/CaiTests/SecretEndToEndTests.swift
+++ b/Cai/CaiTests/SecretEndToEndTests.swift
@@ -28,7 +28,7 @@ final class SecretEndToEndTests: XCTestCase {
     func testACommandCanUseTheSecretWithoutItEnteringTheCommandLine() async throws {
         // Unquoted in the template: the engine supplies the quotes around the
         // environment reference itself.
-        let template = "printf '%s' {{\(secretName)}}"
+        let template = "printf '%s' {{secrets.\(secretName)}}"
 
         let prepared = try SecretStore.prepareForShell(template: template)
         let rendered = try await TemplateEngine.render(
@@ -52,7 +52,7 @@ final class SecretEndToEndTests: XCTestCase {
         // The sink that matters. Same store, same name, same engine.
         do {
             _ = try await TemplateEngine.render(
-                "Summarize this using {{\(secretName)}}",
+                "Summarize this using {{secrets.\(secretName)}}",
                 vars: ["result": "text"],
                 context: .raw,
                 secrets: nil
@@ -69,7 +69,7 @@ final class SecretEndToEndTests: XCTestCase {
         SecretStore.save("other-value", name: "ZZ_CAI_E2E_OTHER")
         defer { SecretStore.delete("ZZ_CAI_E2E_OTHER") }
 
-        let prepared = try SecretStore.prepareForShell(template: "echo {{\(secretName)}}")
+        let prepared = try SecretStore.prepareForShell(template: "echo {{secrets.\(secretName)}}")
 
         XCTAssertNotNil(prepared.environment?["CAI_SECRET_\(secretName)"])
         XCTAssertNil(

--- a/Cai/CaiTests/SecretPolicyTests.swift
+++ b/Cai/CaiTests/SecretPolicyTests.swift
@@ -1,0 +1,198 @@
+import XCTest
+import CaiActionCore
+@testable import Cai
+
+/// Which sinks may see a secret, and what a secret looks like when it gets there.
+///
+/// This is the security boundary of the feature, so it is table-driven and states
+/// the negative cases first. The one that matters most is the prompt: prompts
+/// render through the same engine as webhook headers and share `Context.raw`, so
+/// nothing about the context distinguishes "send this to a model" from "send this
+/// to an API". Only the call site's `SecretAccess` does.
+final class SecretPolicyTests: XCTestCase {
+
+    private let token = SecretValue("sk-live-0123456789")
+    private var values: [String: SecretValue] { ["NOTION_API_TOKEN": token] }
+
+    // MARK: - Refusal
+
+    func testASinkThatDidNotOptInRefuses() async {
+        // nil access is the default, which is what makes prompts safe without
+        // every prompt call site having to remember anything.
+        for context in [TemplateEngine.Context.raw, .shell, .json, .url] {
+            do {
+                _ = try await TemplateEngine.render(
+                    "Summarize using {{NOTION_API_TOKEN}}",
+                    vars: ["result": "x"],
+                    context: context,
+                    secrets: nil
+                )
+                XCTFail("\(context) resolved a secret without opting in")
+            } catch TemplateEngine.FilterError.secretNotAllowed(let name) {
+                XCTAssertEqual(name, "NOTION_API_TOKEN")
+            } catch {
+                XCTFail("wrong error for \(context): \(error)")
+            }
+        }
+    }
+
+    func testRefusalIsLoudRatherThanEmpty() async {
+        // The failure that must not happen: an action that looks like it worked
+        // and quietly sent no credential.
+        do {
+            let rendered = try await TemplateEngine.render(
+                "curl -H \"Authorization: Bearer {{NOTION_API_TOKEN}}\" https://api.notion.com",
+                vars: [:],
+                context: .shell,
+                secrets: nil
+            )
+            XCTFail("rendered instead of throwing: \(rendered)")
+        } catch is TemplateEngine.FilterError {
+            // correct
+        } catch {
+            XCTFail("wrong error type: \(error)")
+        }
+    }
+
+    func testAMissingSecretIsNamedRatherThanSubstitutedEmpty() async {
+        do {
+            _ = try await TemplateEngine.render(
+                "echo {{NO_SUCH_SECRET}}",
+                vars: [:],
+                context: .shell,
+                secrets: .environmentReference(values)
+            )
+            XCTFail("resolved a secret that does not exist")
+        } catch TemplateEngine.FilterError.unknownSecret(let name) {
+            XCTAssertEqual(name, "NO_SUCH_SECRET")
+        } catch {
+            XCTFail("wrong error: \(error)")
+        }
+    }
+
+    // MARK: - The filter allowlist
+
+    func testTheLLMFilterCannotBeAppliedToASecret() async {
+        for access in [TemplateEngine.SecretAccess.substituted(values), .environmentReference(values)] {
+            do {
+                _ = try await TemplateEngine.render(
+                    "{{NOTION_API_TOKEN|llm:\"describe this\"}}",
+                    vars: [:],
+                    context: .raw,
+                    secrets: access
+                )
+                XCTFail("a secret went through |llm")
+            } catch TemplateEngine.FilterError.secretThroughFilter(let name, let filter) {
+                XCTAssertEqual(name, "NOTION_API_TOKEN")
+                XCTAssertEqual(filter, "llm")
+            } catch TemplateEngine.FilterError.badArgument {
+                // environmentReference rejects any filter at all, which is stricter
+            } catch {
+                XCTFail("wrong error: \(error)")
+            }
+        }
+    }
+
+    func testTheAllowlistHoldsOnlyEscapingFilters() {
+        XCTAssertEqual(TemplateEngine.filtersAllowedOnSecrets, ["json", "url_encode", "raw"])
+        XCTAssertFalse(TemplateEngine.filtersAllowedOnSecrets.contains("llm"), "the whole point")
+    }
+
+    func testAnUnknownFilterOnASecretIsRefusedNotLookedUp() async {
+        do {
+            _ = try await TemplateEngine.render(
+                "{{NOTION_API_TOKEN|exfiltrate}}",
+                vars: [:],
+                context: .raw,
+                secrets: .substituted(values)
+            )
+            XCTFail("an unknown filter was allowed on a secret")
+        } catch TemplateEngine.FilterError.secretThroughFilter(_, let filter) {
+            XCTAssertEqual(filter, "exfiltrate", "refused by the allowlist before the registry is consulted")
+        } catch {
+            XCTFail("wrong error: \(error)")
+        }
+    }
+
+    // MARK: - Shell: the value never enters the command
+
+    func testAShellCommandGetsAnEnvironmentReferenceNotTheValue() async throws {
+        let rendered = try await TemplateEngine.render(
+            "curl -H \"Authorization: Bearer {{NOTION_API_TOKEN}}\" https://api.notion.com",
+            vars: [:],
+            context: .shell,
+            secrets: .environmentReference(values)
+        )
+
+        XCTAssertFalse(rendered.contains(token.raw), "the value reached argv, where ps can read it")
+        XCTAssertTrue(rendered.contains("\"$CAI_SECRET_NOTION_API_TOKEN\""))
+    }
+
+    func testTheEnvironmentReferenceIsQuotedSoASpaceCannotSplitIt() async throws {
+        let rendered = try await TemplateEngine.render(
+            "echo {{NOTION_API_TOKEN}}",
+            vars: [:],
+            context: .shell,
+            secrets: .environmentReference(values)
+        )
+        XCTAssertTrue(rendered.hasSuffix("\"$CAI_SECRET_NOTION_API_TOKEN\""))
+    }
+
+    func testTheShellSafetyFilterIsNotAppliedToAnEnvironmentReference() async throws {
+        // |shell would single-quote it, and '$CAI_SECRET_X' does not expand.
+        let rendered = try await TemplateEngine.render(
+            "echo {{NOTION_API_TOKEN}}",
+            vars: [:],
+            context: .shell,
+            secrets: .environmentReference(values)
+        )
+        XCTAssertFalse(rendered.contains("'$CAI_SECRET_NOTION_API_TOKEN'"))
+    }
+
+    // MARK: - Substitution, for the sinks that need the real value
+
+    func testASubstitutedSecretCarriesTheValue() async throws {
+        let rendered = try await TemplateEngine.render(
+            "Authorization: Bearer {{NOTION_API_TOKEN}}",
+            vars: [:],
+            context: .raw,
+            secrets: .substituted(values)
+        )
+        XCTAssertEqual(rendered, "Authorization: Bearer \(token.raw)")
+    }
+
+    func testASubstitutedSecretIsJSONEscapedInAJSONBody() async throws {
+        let quoted = SecretValue("with\"quote")
+        let rendered = try await TemplateEngine.render(
+            "{\"token\": \"{{TOKEN}}\"}",
+            vars: [:],
+            context: .json,
+            secrets: .substituted(["TOKEN": quoted])
+        )
+        XCTAssertTrue(rendered.contains("with\\\"quote"), "an unescaped quote would break the body: \(rendered)")
+    }
+
+    // MARK: - Ordinary variables are untouched
+
+    func testLowercaseVariablesBehaveExactlyAsBefore() async throws {
+        let rendered = try await TemplateEngine.render(
+            "echo {{result}}",
+            vars: ["result": "hello"],
+            context: .shell,
+            secrets: nil
+        )
+        XCTAssertEqual(rendered, "echo 'hello'")
+    }
+
+    func testAnUnknownLowercaseVariableStillResolvesToEmpty() async throws {
+        // Deliberately unchanged: templates get copied between contexts and a
+        // stray {{title}} should not kill the action. Secrets are the exception.
+        let rendered = try await TemplateEngine.render(
+            "echo [{{title}}]",
+            vars: [:],
+            context: .raw,
+            secrets: nil
+        )
+        XCTAssertEqual(rendered, "echo []")
+    }
+}

--- a/Cai/CaiTests/SecretPolicyTests.swift
+++ b/Cai/CaiTests/SecretPolicyTests.swift
@@ -12,7 +12,9 @@ import CaiActionCore
 final class SecretPolicyTests: XCTestCase {
 
     private let token = SecretValue("sk-live-0123456789")
-    private var values: [String: SecretValue] { ["NOTION_API_TOKEN": token] }
+    private var access: TemplateEngine.SecretAccess {
+        TemplateEngine.SecretAccess(values: ["NOTION_API_TOKEN": token])
+    }
 
     // MARK: - Refusal
 
@@ -22,7 +24,7 @@ final class SecretPolicyTests: XCTestCase {
         for context in [TemplateEngine.Context.raw, .shell, .json, .url] {
             do {
                 _ = try await TemplateEngine.render(
-                    "Summarize using {{NOTION_API_TOKEN}}",
+                    "Summarize using {{secrets.NOTION_API_TOKEN}}",
                     vars: ["result": "x"],
                     context: context,
                     secrets: nil
@@ -41,7 +43,7 @@ final class SecretPolicyTests: XCTestCase {
         // and quietly sent no credential.
         do {
             let rendered = try await TemplateEngine.render(
-                "curl -H \"Authorization: Bearer {{NOTION_API_TOKEN}}\" https://api.notion.com",
+                "curl -H \"Authorization: Bearer {{secrets.NOTION_API_TOKEN}}\" https://api.notion.com",
                 vars: [:],
                 context: .shell,
                 secrets: nil
@@ -57,10 +59,10 @@ final class SecretPolicyTests: XCTestCase {
     func testAMissingSecretIsNamedRatherThanSubstitutedEmpty() async {
         do {
             _ = try await TemplateEngine.render(
-                "echo {{NO_SUCH_SECRET}}",
+                "echo {{secrets.NO_SUCH_SECRET}}",
                 vars: [:],
                 context: .shell,
-                secrets: .environmentReference(values)
+                secrets: access
             )
             XCTFail("resolved a secret that does not exist")
         } catch TemplateEngine.FilterError.unknownSecret(let name) {
@@ -70,30 +72,44 @@ final class SecretPolicyTests: XCTestCase {
         }
     }
 
-    // MARK: - The filter allowlist
-
-    func testTheLLMFilterCannotBeAppliedToASecret() async {
-        for access in [TemplateEngine.SecretAccess.substituted(values), .environmentReference(values)] {
-            do {
-                _ = try await TemplateEngine.render(
-                    "{{NOTION_API_TOKEN|llm:\"describe this\"}}",
-                    vars: [:],
-                    context: .raw,
-                    secrets: access
-                )
-                XCTFail("a secret went through |llm")
-            } catch TemplateEngine.FilterError.secretThroughFilter(let name, let filter) {
-                XCTAssertEqual(name, "NOTION_API_TOKEN")
-                XCTAssertEqual(filter, "llm")
-            } catch TemplateEngine.FilterError.badArgument {
-                // environmentReference rejects any filter at all, which is stricter
-            } catch {
-                XCTFail("wrong error: \(error)")
-            }
+    func testABrokenNameInTheNamespaceIsLoud() async {
+        // `{{secrets.lowercase}}` is a secret reference written wrong, not an
+        // unknown ordinary variable, so it must not render as empty.
+        do {
+            _ = try await TemplateEngine.render(
+                "echo {{secrets.notion_token}}",
+                vars: [:],
+                context: .shell,
+                secrets: nil
+            )
+            XCTFail("a malformed secret reference rendered")
+        } catch TemplateEngine.FilterError.parseError {
+            // correct
+        } catch {
+            XCTFail("wrong error: \(error)")
         }
     }
 
-    func testTheAllowlistHoldsOnlyEscapingFilters() {
+    // MARK: - The filter allowlist
+
+    func testTheLLMFilterCannotBeAppliedToASecret() async {
+        do {
+            _ = try await TemplateEngine.render(
+                "{{secrets.NOTION_API_TOKEN|llm:\"describe this\"}}",
+                vars: [:],
+                context: .shell,
+                secrets: access
+            )
+            XCTFail("a secret went through |llm")
+        } catch TemplateEngine.FilterError.secretThroughFilter(let name, let filter) {
+            XCTAssertEqual(name, "NOTION_API_TOKEN")
+            XCTAssertEqual(filter, "llm")
+        } catch {
+            XCTFail("wrong error: \(error)")
+        }
+    }
+
+    func testTheAllowlistNeverContainsLLM() {
         XCTAssertEqual(TemplateEngine.filtersAllowedOnSecrets, ["json", "url_encode", "raw"])
         XCTAssertFalse(TemplateEngine.filtersAllowedOnSecrets.contains("llm"), "the whole point")
     }
@@ -101,10 +117,10 @@ final class SecretPolicyTests: XCTestCase {
     func testAnUnknownFilterOnASecretIsRefusedNotLookedUp() async {
         do {
             _ = try await TemplateEngine.render(
-                "{{NOTION_API_TOKEN|exfiltrate}}",
+                "{{secrets.NOTION_API_TOKEN|exfiltrate}}",
                 vars: [:],
-                context: .raw,
-                secrets: .substituted(values)
+                context: .shell,
+                secrets: access
             )
             XCTFail("an unknown filter was allowed on a secret")
         } catch TemplateEngine.FilterError.secretThroughFilter(_, let filter) {
@@ -114,26 +130,56 @@ final class SecretPolicyTests: XCTestCase {
         }
     }
 
+    func testAnEscapingFilterOnASecretIsRefusedGently() async {
+        // |json cannot apply to a value that never enters the output; the error
+        // says so instead of pretending to escape something.
+        do {
+            _ = try await TemplateEngine.render(
+                "echo {{secrets.NOTION_API_TOKEN|json}}",
+                vars: [:],
+                context: .shell,
+                secrets: access
+            )
+            XCTFail("an escaping filter was applied to an environment reference")
+        } catch TemplateEngine.FilterError.badArgument(_, let filter) {
+            XCTAssertEqual(filter, "json")
+        } catch {
+            XCTFail("wrong error: \(error)")
+        }
+    }
+
+    func testRawIsANoOpOnASecret() async throws {
+        // Docs teach |raw as "no escaping", which is what an environment
+        // reference already is. Refusing it would only generate support noise.
+        let rendered = try await TemplateEngine.render(
+            "echo {{secrets.NOTION_API_TOKEN|raw}}",
+            vars: [:],
+            context: .shell,
+            secrets: access
+        )
+        XCTAssertTrue(rendered.hasSuffix("\"$CAI_SECRET_NOTION_API_TOKEN\""))
+    }
+
     // MARK: - Shell: the value never enters the command
 
     func testAShellCommandGetsAnEnvironmentReferenceNotTheValue() async throws {
         let rendered = try await TemplateEngine.render(
-            "curl -H \"Authorization: Bearer {{NOTION_API_TOKEN}}\" https://api.notion.com",
+            "curl -H \"Authorization: Bearer {{secrets.NOTION_API_TOKEN}}\" https://api.notion.com",
             vars: [:],
             context: .shell,
-            secrets: .environmentReference(values)
+            secrets: access
         )
 
-        XCTAssertFalse(rendered.contains(token.raw), "the value reached argv, where ps can read it")
+        XCTAssertFalse(rendered.contains(token.raw), "the value reached argv")
         XCTAssertTrue(rendered.contains("\"$CAI_SECRET_NOTION_API_TOKEN\""))
     }
 
     func testTheEnvironmentReferenceIsQuotedSoASpaceCannotSplitIt() async throws {
         let rendered = try await TemplateEngine.render(
-            "echo {{NOTION_API_TOKEN}}",
+            "echo {{secrets.NOTION_API_TOKEN}}",
             vars: [:],
             context: .shell,
-            secrets: .environmentReference(values)
+            secrets: access
         )
         XCTAssertTrue(rendered.hasSuffix("\"$CAI_SECRET_NOTION_API_TOKEN\""))
     }
@@ -141,35 +187,70 @@ final class SecretPolicyTests: XCTestCase {
     func testTheShellSafetyFilterIsNotAppliedToAnEnvironmentReference() async throws {
         // |shell would single-quote it, and '$CAI_SECRET_X' does not expand.
         let rendered = try await TemplateEngine.render(
-            "echo {{NOTION_API_TOKEN}}",
+            "echo {{secrets.NOTION_API_TOKEN}}",
             vars: [:],
             context: .shell,
-            secrets: .environmentReference(values)
+            secrets: access
         )
         XCTAssertFalse(rendered.contains("'$CAI_SECRET_NOTION_API_TOKEN'"))
     }
 
-    // MARK: - Substitution, for the sinks that need the real value
+    // MARK: - Single quotes: refuse rather than misfire
 
-    func testASubstitutedSecretCarriesTheValue() async throws {
-        let rendered = try await TemplateEngine.render(
-            "Authorization: Bearer {{NOTION_API_TOKEN}}",
-            vars: [:],
-            context: .raw,
-            secrets: .substituted(values)
-        )
-        XCTAssertEqual(rendered, "Authorization: Bearer \(token.raw)")
+    func testAReferenceInsideSingleQuotesIsRefused() async {
+        // 'Bearer "$CAI_SECRET_X"' would send the literal text as the
+        // credential: a silent 401 the user cannot diagnose. Loud instead.
+        do {
+            _ = try await TemplateEngine.render(
+                "curl -H 'Authorization: Bearer {{secrets.NOTION_API_TOKEN}}' https://api.notion.com",
+                vars: [:],
+                context: .shell,
+                secrets: access
+            )
+            XCTFail("a reference inside single quotes rendered")
+        } catch TemplateEngine.FilterError.secretInSingleQuotes(let name) {
+            XCTAssertEqual(name, "NOTION_API_TOKEN")
+        } catch {
+            XCTFail("wrong error: \(error)")
+        }
     }
 
-    func testASubstitutedSecretIsJSONEscapedInAJSONBody() async throws {
-        let quoted = SecretValue("with\"quote")
+    func testAnApostropheInsideDoubleQuotesDoesNotFalsePositive() async throws {
+        // "it's" must not count as an opened single quote.
         let rendered = try await TemplateEngine.render(
-            "{\"token\": \"{{TOKEN}}\"}",
+            "echo \"it's here:\" {{secrets.NOTION_API_TOKEN}}",
             vars: [:],
-            context: .json,
-            secrets: .substituted(["TOKEN": quoted])
+            context: .shell,
+            secrets: access
         )
-        XCTAssertTrue(rendered.contains("with\\\"quote"), "an unescaped quote would break the body: \(rendered)")
+        XCTAssertTrue(rendered.hasSuffix("\"$CAI_SECRET_NOTION_API_TOKEN\""))
+    }
+
+    func testAClosedSingleQuoteBeforeTheReferenceIsFine() async throws {
+        let rendered = try await TemplateEngine.render(
+            "echo 'prefix' {{secrets.NOTION_API_TOKEN}}",
+            vars: [:],
+            context: .shell,
+            secrets: access
+        )
+        XCTAssertTrue(rendered.hasSuffix("\"$CAI_SECRET_NOTION_API_TOKEN\""))
+    }
+
+    func testQuoteStateTracking() {
+        let cases: [(String, Bool, String)] = [
+            ("", false, "empty"),
+            ("echo ", false, "no quotes"),
+            ("echo '", true, "open single"),
+            ("echo 'a'", false, "closed single"),
+            ("echo \"it's\" ", false, "apostrophe inside double quotes"),
+            ("echo \"a\" '", true, "double closed, single open"),
+            ("echo \\' ", false, "escaped quote outside quotes"),
+            ("echo 'can\\'", false, "backslash inside single quotes does not escape; the quote closes"),
+            ("echo \"\\\"\" '", true, "escaped double quote inside double quotes, then open single"),
+        ]
+        for (prefix, expected, why) in cases {
+            XCTAssertEqual(TemplateEngine.endsInsideSingleQuote(prefix), expected, "\(prefix): \(why)")
+        }
     }
 
     // MARK: - Ordinary variables are untouched
@@ -184,15 +265,29 @@ final class SecretPolicyTests: XCTestCase {
         XCTAssertEqual(rendered, "echo 'hello'")
     }
 
-    func testAnUnknownLowercaseVariableStillResolvesToEmpty() async throws {
-        // Deliberately unchanged: templates get copied between contexts and a
-        // stray {{title}} should not kill the action. Secrets are the exception.
+    func testUppercaseVariablesAreOrdinaryVariables() async throws {
+        // The regression the `secrets.` namespace exists to prevent: users have
+        // setup fields named API_KEY, and extensions can define any key. Those
+        // placeholders must keep resolving from vars exactly as before.
         let rendered = try await TemplateEngine.render(
-            "echo [{{title}}]",
+            "Bearer {{API_KEY}}",
+            vars: ["API_KEY": "field-value"],
+            context: .raw,
+            secrets: nil
+        )
+        XCTAssertEqual(rendered, "Bearer field-value")
+    }
+
+    func testAnUnknownVariableStillResolvesToEmptyWhateverItsCase() async throws {
+        // Deliberately unchanged: templates get copied between contexts and a
+        // stray {{title}} or {{RESULT}} should not kill the action. Only the
+        // secrets namespace is the exception.
+        let rendered = try await TemplateEngine.render(
+            "echo [{{title}}][{{RESULT}}]",
             vars: [:],
             context: .raw,
             secrets: nil
         )
-        XCTAssertEqual(rendered, "echo []")
+        XCTAssertEqual(rendered, "echo [][]")
     }
 }

--- a/Cai/CaiTests/SecretReferenceTests.swift
+++ b/Cai/CaiTests/SecretReferenceTests.swift
@@ -14,7 +14,7 @@ final class SecretReferenceTests: XCTestCase {
             ("A1_2", true, "digits and underscores after the first letter"),
             ("A", false, "one character"),
             ("", false, "empty"),
-            ("notion_token", false, "lowercase, which is what ordinary variables look like"),
+            ("notion_token", false, "lowercase"),
             ("Notion_Token", false, "mixed case"),
             ("1TOKEN", false, "leading digit"),
             ("_TOKEN", false, "leading underscore"),
@@ -31,14 +31,6 @@ final class SecretReferenceTests: XCTestCase {
         }
     }
 
-    func testTheReservedVariableCannotBeShadowed() {
-        // Ordinary variables are lowercase, so a secret can never collide with
-        // `result` or with an MCP form key. This is the structural guarantee
-        // behind the naming rule, so it is worth pinning.
-        XCTAssertFalse(SecretReference.isValidName("result"))
-        XCTAssertFalse(SecretReference.isValidName("repo_owner"))
-    }
-
     func testRejectionsExplainThemselves() {
         XCTAssertNil(SecretReference.nameRejection("NOTION_API_TOKEN"))
         XCTAssertEqual(SecretReference.nameRejection(""), "Give the secret a name.")
@@ -46,6 +38,32 @@ final class SecretReferenceTests: XCTestCase {
         XCTAssertTrue(SecretReference.nameRejection("token")?.contains("upper-case letter") == true)
         XCTAssertTrue(SecretReference.nameRejection("MY-TOKEN")?.contains("underscores") == true)
         XCTAssertTrue(SecretReference.nameRejection(String(repeating: "A", count: 99))?.contains("64") == true)
+    }
+
+    // MARK: - The namespace
+
+    func testNameFromReference() {
+        let cases: [(String, String?, String)] = [
+            ("secrets.NOTION_API_TOKEN", "NOTION_API_TOKEN", "the ordinary case"),
+            ("secrets.AB", "AB", "shortest valid name"),
+            ("result", nil, "no namespace"),
+            ("NOTION_API_TOKEN", nil, "bare uppercase is an ordinary variable, the pre-namespace syntax must not resolve"),
+            ("secrets.notion_token", nil, "namespace claimed but the name is broken"),
+            ("secrets.", nil, "namespace with nothing after it"),
+            ("secrets", nil, "the namespace word alone is an ordinary variable"),
+            ("Secrets.TOKEN", nil, "namespace is case-sensitive"),
+        ]
+        for (variable, expected, why) in cases {
+            XCTAssertEqual(SecretReference.name(fromReference: variable), expected, "\(variable): \(why)")
+        }
+    }
+
+    func testClaimsNamespaceSeparatesWrongFromAbsent() {
+        // "written wrong" (engine throws loud) vs "not a secret" (ordinary var).
+        XCTAssertTrue(SecretReference.claimsNamespace("secrets.bad-name"))
+        XCTAssertTrue(SecretReference.claimsNamespace("secrets."))
+        XCTAssertFalse(SecretReference.claimsNamespace("API_KEY"))
+        XCTAssertFalse(SecretReference.claimsNamespace("secrets"))
     }
 
     // MARK: - Keychain accounts
@@ -84,16 +102,16 @@ final class SecretReferenceTests: XCTestCase {
             ("", [], "empty template"),
             ("echo hello", [], "no placeholders"),
             ("echo {{result}}", [], "an ordinary variable is not a secret"),
-            ("echo {{TOKEN}}", ["TOKEN"], "one"),
-            ("{{A_TOKEN}} and {{B_TOKEN}}", ["A_TOKEN", "B_TOKEN"], "two"),
-            ("{{TOKEN}} {{TOKEN}}", ["TOKEN"], "repeated collapses"),
-            ("{{TOKEN|json}}", ["TOKEN"], "filters are ignored"),
-            ("{{ TOKEN }}", ["TOKEN"], "surrounding whitespace, which the engine also trims"),
-            ("{{result|llm:\"use {{TOKEN}}\"}}", [], "nested in a filter argument is literal text, so no value is ever resolved and there is nothing to refuse"),
-            ("{{TOKEN", [], "unterminated"),
-            ("{TOKEN}", [], "single braces"),
+            ("echo {{TOKEN}}", [], "bare uppercase is an ordinary variable now"),
+            ("echo {{secrets.TOKEN}}", ["TOKEN"], "one"),
+            ("{{secrets.A_TOKEN}} and {{secrets.B_TOKEN}}", ["A_TOKEN", "B_TOKEN"], "two"),
+            ("{{secrets.TOKEN}} {{secrets.TOKEN}}", ["TOKEN"], "repeated collapses"),
+            ("{{secrets.TOKEN|json}}", ["TOKEN"], "filters are ignored"),
+            ("{{ secrets.TOKEN }}", ["TOKEN"], "surrounding whitespace, which the engine also trims"),
+            ("{{secrets.TOKEN", [], "unterminated"),
+            ("{secrets.TOKEN}", [], "single braces"),
             ("{{}}", [], "empty placeholder"),
-            ("{{lower}} {{UPPER}}", ["UPPER"], "mixed"),
+            ("{{secrets.bad-name}}", [], "broken name; the engine refuses it loudly instead"),
         ]
 
         for (template, expected, why) in cases {
@@ -102,39 +120,75 @@ final class SecretReferenceTests: XCTestCase {
     }
 
     func testReferencesAnySecret() {
-        XCTAssertTrue(SecretReference.referencesAnySecret("curl -H \"Bearer {{TOKEN}}\""))
-        XCTAssertFalse(SecretReference.referencesAnySecret("echo {{result}}"))
+        XCTAssertTrue(SecretReference.referencesAnySecret("curl -H \"Bearer {{secrets.TOKEN}}\""))
+        XCTAssertFalse(SecretReference.referencesAnySecret("echo {{result}} {{TOKEN}}"))
     }
 
     // MARK: - Agreement with the engine's own parser
 
-    /// `SecretReference.names(in:)` is a second, deliberately independent scanner:
-    /// it lives in the shared package so the validator can use it, while the
-    /// engine's parser stays in the app. Two parsers is a drift risk, and the
-    /// dangerous direction is the validator saying "no secret here" while the
-    /// engine happily resolves one. This pins them together on a corpus.
-    func testTheScannerAgreesWithTheEngineOnWhatIsASecret() async throws {
+    /// The package scanner is quote-blind and the engine's parser is not, so on
+    /// templates with `}}` inside quoted filter args they genuinely disagree.
+    /// The contract that matters is the direction: the scanner may over-report
+    /// (a proposal looks slightly scarier than it is) but must never
+    /// under-report (a credential hidden from the approval sheet). Execution
+    /// never trusts the scanner — `prepareForShell` uses
+    /// `TemplateEngine.secretNames` — so over-reporting cannot put a secret in
+    /// any environment.
+    func testTheScannerNeverUnderReportsAgainstTheEngine() {
         let corpus = [
             "echo {{result}}",
-            "echo {{TOKEN}}",
-            "curl -H \"Authorization: Bearer {{NOTION_API_TOKEN}}\" https://api.notion.com",
-            "{{A}} {{B_2}} {{result|shell}}",
-            "{{TOKEN|json}}",
-            "{{ TOKEN }}",
+            "echo {{secrets.TOKEN}}",
+            "curl -H \"Authorization: Bearer {{secrets.NOTION_API_TOKEN}}\" https://api.notion.com",
+            "{{secrets.A}} {{secrets.B_2}} {{result|shell}}",
+            "{{secrets.TOKEN|json}}",
+            "{{ secrets.TOKEN }}",
+            "{{TOKEN}} {{API_KEY}}",
             "plain text, no placeholders",
+            // The divergence class: `}}` inside a quoted filter arg. The engine
+            // sees one placeholder and no secret; the scanner desyncs and
+            // over-reports AWS_KEY. That direction is allowed.
+            "{{result|llm:\"see }} {{secrets.AWS_KEY}} docs\"}}",
         ]
 
         for template in corpus {
             let scanned = SecretReference.names(in: template)
+            let engine = TemplateEngine.secretNames(in: template)
+            XCTAssertTrue(
+                engine.isSubset(of: scanned),
+                "the engine resolves \(engine) in \(template) but the scanner only saw \(scanned)"
+            )
+        }
+    }
 
-            // What the engine does with the same template: if the scanner found
-            // nothing, rendering with no access must succeed, and if it found
-            // something, rendering must be refused.
+    func testEngineNamesFollowTheParserNotTheScanner() {
+        // The template where the two disagree: prepareForShell must side with
+        // the engine, or a secret lands in the environment of a command that
+        // never references it.
+        let template = "{{result|llm:\"see }} {{secrets.AWS_KEY}} docs\"}}"
+        XCTAssertEqual(TemplateEngine.secretNames(in: template), [])
+        XCTAssertEqual(SecretReference.names(in: template), ["AWS_KEY"], "over-reporting is the accepted direction")
+    }
+
+    /// The engine's own extraction matches what rendering refuses: if
+    /// `secretNames` is empty, rendering with no access succeeds; if not, it is
+    /// refused with one of the names.
+    func testEngineNamesAgreeWithRendering() async throws {
+        let corpus = [
+            "echo {{result}}",
+            "echo {{secrets.TOKEN}}",
+            "curl -H \"Authorization: Bearer {{secrets.NOTION_API_TOKEN}}\" https://api.notion.com",
+            "{{ secrets.TOKEN }}",
+            "{{TOKEN}} {{API_KEY}}",
+            "plain text, no placeholders",
+        ]
+
+        for template in corpus {
+            let names = TemplateEngine.secretNames(in: template)
             do {
                 _ = try await TemplateEngine.render(template, vars: ["result": "x"], context: .raw, secrets: nil)
-                XCTAssertTrue(scanned.isEmpty, "the engine rendered \(template) but the scanner claimed secrets \(scanned)")
+                XCTAssertTrue(names.isEmpty, "the engine rendered \(template) but claimed secrets \(names)")
             } catch TemplateEngine.FilterError.secretNotAllowed(let name) {
-                XCTAssertTrue(scanned.contains(name), "the engine refused \(name) in \(template) but the scanner missed it")
+                XCTAssertTrue(names.contains(name), "the engine refused \(name) in \(template) but secretNames missed it")
             }
         }
     }

--- a/Cai/CaiTests/SecretReferenceTests.swift
+++ b/Cai/CaiTests/SecretReferenceTests.swift
@@ -1,0 +1,141 @@
+import XCTest
+import CaiActionCore
+@testable import Cai
+
+/// Names, and finding references to them in a template.
+final class SecretReferenceTests: XCTestCase {
+
+    // MARK: - Names
+
+    func testNameValidity() {
+        let cases: [(String, Bool, String)] = [
+            ("NOTION_API_TOKEN", true, "the ordinary case"),
+            ("AB", true, "two characters is the floor"),
+            ("A1_2", true, "digits and underscores after the first letter"),
+            ("A", false, "one character"),
+            ("", false, "empty"),
+            ("notion_token", false, "lowercase, which is what ordinary variables look like"),
+            ("Notion_Token", false, "mixed case"),
+            ("1TOKEN", false, "leading digit"),
+            ("_TOKEN", false, "leading underscore"),
+            ("MY-TOKEN", false, "hyphen"),
+            ("MY TOKEN", false, "space"),
+            ("TOKEN!", false, "punctuation"),
+            ("TÖKEN", false, "non-ASCII, which would not survive an environment variable"),
+            (String(repeating: "A", count: 64), true, "at the length limit"),
+            (String(repeating: "A", count: 65), false, "past the length limit"),
+        ]
+
+        for (name, expected, why) in cases {
+            XCTAssertEqual(SecretReference.isValidName(name), expected, "\(name): \(why)")
+        }
+    }
+
+    func testTheReservedVariableCannotBeShadowed() {
+        // Ordinary variables are lowercase, so a secret can never collide with
+        // `result` or with an MCP form key. This is the structural guarantee
+        // behind the naming rule, so it is worth pinning.
+        XCTAssertFalse(SecretReference.isValidName("result"))
+        XCTAssertFalse(SecretReference.isValidName("repo_owner"))
+    }
+
+    func testRejectionsExplainThemselves() {
+        XCTAssertNil(SecretReference.nameRejection("NOTION_API_TOKEN"))
+        XCTAssertEqual(SecretReference.nameRejection(""), "Give the secret a name.")
+        XCTAssertTrue(SecretReference.nameRejection("a")?.contains("two characters") == true)
+        XCTAssertTrue(SecretReference.nameRejection("token")?.contains("upper-case letter") == true)
+        XCTAssertTrue(SecretReference.nameRejection("MY-TOKEN")?.contains("underscores") == true)
+        XCTAssertTrue(SecretReference.nameRejection(String(repeating: "A", count: 99))?.contains("64") == true)
+    }
+
+    // MARK: - Keychain accounts
+
+    func testAccountRoundTrip() {
+        let account = SecretReference.accountName(for: "NOTION_API_TOKEN")
+        XCTAssertEqual(account, "cai_secret_NOTION_API_TOKEN")
+        XCTAssertEqual(SecretReference.name(fromAccount: account), "NOTION_API_TOKEN")
+    }
+
+    func testTheModelAPIKeysAreNotMistakenForSecrets() {
+        // They share the Keychain service, so the prefix is what separates them.
+        for account in ["cai_apiKey", "cai_anthropicApiKey", "cai_openRouterApiKey"] {
+            XCTAssertNil(SecretReference.name(fromAccount: account), account)
+        }
+    }
+
+    func testAnAccountWithAnInvalidNameIsIgnored() {
+        // Someone editing Keychain Access by hand cannot inject a name the rest
+        // of the system would then treat as valid.
+        XCTAssertNil(SecretReference.name(fromAccount: "cai_secret_lowercase"))
+        XCTAssertNil(SecretReference.name(fromAccount: "cai_secret_"))
+    }
+
+    func testEnvironmentVariableName() {
+        XCTAssertEqual(
+            SecretReference.environmentVariable(for: "NOTION_API_TOKEN"),
+            "CAI_SECRET_NOTION_API_TOKEN"
+        )
+    }
+
+    // MARK: - Finding references
+
+    func testFindingReferences() {
+        let cases: [(String, Set<String>, String)] = [
+            ("", [], "empty template"),
+            ("echo hello", [], "no placeholders"),
+            ("echo {{result}}", [], "an ordinary variable is not a secret"),
+            ("echo {{TOKEN}}", ["TOKEN"], "one"),
+            ("{{A_TOKEN}} and {{B_TOKEN}}", ["A_TOKEN", "B_TOKEN"], "two"),
+            ("{{TOKEN}} {{TOKEN}}", ["TOKEN"], "repeated collapses"),
+            ("{{TOKEN|json}}", ["TOKEN"], "filters are ignored"),
+            ("{{ TOKEN }}", ["TOKEN"], "surrounding whitespace, which the engine also trims"),
+            ("{{result|llm:\"use {{TOKEN}}\"}}", [], "nested in a filter argument is literal text, so no value is ever resolved and there is nothing to refuse"),
+            ("{{TOKEN", [], "unterminated"),
+            ("{TOKEN}", [], "single braces"),
+            ("{{}}", [], "empty placeholder"),
+            ("{{lower}} {{UPPER}}", ["UPPER"], "mixed"),
+        ]
+
+        for (template, expected, why) in cases {
+            XCTAssertEqual(SecretReference.names(in: template), expected, "\(template): \(why)")
+        }
+    }
+
+    func testReferencesAnySecret() {
+        XCTAssertTrue(SecretReference.referencesAnySecret("curl -H \"Bearer {{TOKEN}}\""))
+        XCTAssertFalse(SecretReference.referencesAnySecret("echo {{result}}"))
+    }
+
+    // MARK: - Agreement with the engine's own parser
+
+    /// `SecretReference.names(in:)` is a second, deliberately independent scanner:
+    /// it lives in the shared package so the validator can use it, while the
+    /// engine's parser stays in the app. Two parsers is a drift risk, and the
+    /// dangerous direction is the validator saying "no secret here" while the
+    /// engine happily resolves one. This pins them together on a corpus.
+    func testTheScannerAgreesWithTheEngineOnWhatIsASecret() async throws {
+        let corpus = [
+            "echo {{result}}",
+            "echo {{TOKEN}}",
+            "curl -H \"Authorization: Bearer {{NOTION_API_TOKEN}}\" https://api.notion.com",
+            "{{A}} {{B_2}} {{result|shell}}",
+            "{{TOKEN|json}}",
+            "{{ TOKEN }}",
+            "plain text, no placeholders",
+        ]
+
+        for template in corpus {
+            let scanned = SecretReference.names(in: template)
+
+            // What the engine does with the same template: if the scanner found
+            // nothing, rendering with no access must succeed, and if it found
+            // something, rendering must be refused.
+            do {
+                _ = try await TemplateEngine.render(template, vars: ["result": "x"], context: .raw, secrets: nil)
+                XCTAssertTrue(scanned.isEmpty, "the engine rendered \(template) but the scanner claimed secrets \(scanned)")
+            } catch TemplateEngine.FilterError.secretNotAllowed(let name) {
+                XCTAssertTrue(scanned.contains(name), "the engine refused \(name) in \(template) but the scanner missed it")
+            }
+        }
+    }
+}

--- a/Cai/CaiTests/SecretStoreTests.swift
+++ b/Cai/CaiTests/SecretStoreTests.swift
@@ -1,0 +1,170 @@
+import XCTest
+import CaiActionCore
+@testable import Cai
+
+/// `SecretStore`, `SecretValue` and `Redactor`.
+///
+/// The store tests touch the real Keychain, under names prefixed so they cannot
+/// collide with anything a developer actually stores, and each one cleans up
+/// after itself. That is worth the cost: the Keychain-as-the-list decision rests
+/// on enumeration returning names without values, and a mock would pin the mock.
+final class SecretStoreTests: XCTestCase {
+
+    private let testName = "ZZ_CAI_TEST_SECRET"
+    private let otherName = "ZZ_CAI_TEST_OTHER"
+
+    override func tearDown() {
+        SecretStore.delete(testName)
+        SecretStore.delete(otherName)
+        super.tearDown()
+    }
+
+    // MARK: - SecretValue cannot be logged by accident
+
+    func testTheValueDoesNotAppearInAnyStringConversion() {
+        let secret = SecretValue("sk-live-should-never-print")
+
+        XCTAssertEqual("\(secret)", "<redacted>", "string interpolation is the common accident")
+        XCTAssertEqual(String(describing: secret), "<redacted>")
+        XCTAssertEqual(String(reflecting: secret), "<redacted>")
+        XCTAssertEqual(secret.description, "<redacted>")
+        XCTAssertEqual(secret.debugDescription, "<redacted>")
+        XCTAssertFalse("\(secret)".contains("sk-live"))
+    }
+
+    func testTheValueIsStillReachableDeliberately() {
+        XCTAssertEqual(SecretValue("abc").raw, "abc", "explicit .raw is the only way in, and it greps")
+    }
+
+    // MARK: - Store round trip
+
+    func testSaveThenReadThenDelete() {
+        XCTAssertEqual(SecretStore.save("first-value", name: testName), .saved)
+        XCTAssertEqual(SecretStore.value(for: testName)?.raw, "first-value")
+
+        XCTAssertEqual(SecretStore.save("second-value", name: testName), .replaced, "overwrite is how rotation works")
+        XCTAssertEqual(SecretStore.value(for: testName)?.raw, "second-value")
+
+        XCTAssertTrue(SecretStore.delete(testName))
+        XCTAssertNil(SecretStore.value(for: testName))
+    }
+
+    func testDeletingSomethingAbsentSucceeds() {
+        XCTAssertTrue(SecretStore.delete(testName), "idempotent, so a double delete is not an error")
+    }
+
+    func testAnInvalidNameIsRejectedBeforeTheKeychain() {
+        guard case .invalidName(let message) = SecretStore.save("v", name: "bad name") else {
+            return XCTFail("an invalid name reached the Keychain")
+        }
+        XCTAssertFalse(message.isEmpty)
+        XCTAssertNil(SecretStore.value(for: "bad name"))
+    }
+
+    func testAnEmptyValueIsStorable() {
+        // Not our business to police the token format, and refusing would be a
+        // confusing failure at save time.
+        XCTAssertEqual(SecretStore.save("", name: testName), .saved)
+        XCTAssertEqual(SecretStore.value(for: testName)?.raw, "")
+    }
+
+    // MARK: - Enumeration
+
+    func testTheListReportsNamesAndDatesWithoutValues() throws {
+        SecretStore.save("value-a", name: testName)
+
+        let entry = try XCTUnwrap(SecretStore.list().first { $0.name == testName })
+        XCTAssertNotNil(entry.created, "the list shows an Added date, which the Keychain supplies for free")
+        XCTAssertFalse("\(entry)".contains("value-a"), "no descriptor may carry the value")
+    }
+
+    func testTheListIgnoresTheModelAPIKeys() {
+        SecretStore.save("value-a", name: testName)
+
+        let names = SecretStore.list().map(\.name)
+        XCTAssertTrue(names.contains(testName))
+        for foreign in ["cai_apiKey", "cai_anthropicApiKey", "cai_openRouterApiKey"] {
+            XCTAssertFalse(names.contains(foreign), "\(foreign) shares the service but is not a secret")
+        }
+    }
+
+    func testTheListIsSortedByName() {
+        SecretStore.save("v", name: otherName)   // ZZ_CAI_TEST_OTHER
+        SecretStore.save("v", name: testName)    // ZZ_CAI_TEST_SECRET
+
+        let ours = SecretStore.list().map(\.name).filter { $0.hasPrefix("ZZ_CAI_TEST") }
+        XCTAssertEqual(ours, [otherName, testName])
+    }
+
+    func testExists() {
+        XCTAssertFalse(SecretStore.exists(testName))
+        SecretStore.save("v", name: testName)
+        XCTAssertTrue(SecretStore.exists(testName))
+    }
+
+    // MARK: - Resolution for a shell command
+
+    func testATemplateWithoutSecretsChangesNothing() throws {
+        let prepared = try SecretStore.prepareForShell(template: "echo {{result}}")
+
+        XCTAssertTrue(prepared.isEmpty)
+        XCTAssertNil(prepared.access, "no access means the engine keeps refusing")
+        XCTAssertNil(prepared.environment, "the runner keeps its default environment")
+    }
+
+    func testPreparationPutsTheValueInTheEnvironment() throws {
+        SecretStore.save("sk-live-xyz", name: testName)
+
+        let prepared = try SecretStore.prepareForShell(template: "curl -H \"Bearer {{\(testName)}}\"")
+
+        XCTAssertEqual(prepared.environment?["CAI_SECRET_\(testName)"], "sk-live-xyz")
+        XCTAssertNotNil(prepared.environment?["PATH"], "the Homebrew PATH must survive")
+        XCTAssertEqual(prepared.values.count, 1)
+    }
+
+    func testPreparationFailsOnAMissingSecret() {
+        do {
+            _ = try SecretStore.prepareForShell(template: "echo {{ZZ_CAI_TEST_ABSENT}}")
+            XCTFail("a missing secret was resolved to nothing")
+        } catch TemplateEngine.FilterError.unknownSecret(let name) {
+            XCTAssertEqual(name, "ZZ_CAI_TEST_ABSENT")
+        } catch {
+            XCTFail("wrong error: \(error)")
+        }
+    }
+
+    // MARK: - Redaction
+
+    func testRedactionReplacesEveryOccurrence() {
+        let secret = SecretValue("sk-live-abcdef")
+        let text = "failed with sk-live-abcdef and again sk-live-abcdef"
+
+        let redacted = Redactor.redact(text, using: [secret])
+
+        XCTAssertFalse(redacted.contains("sk-live-abcdef"))
+        XCTAssertEqual(redacted, "failed with <redacted> and again <redacted>")
+    }
+
+    func testTheLongerSecretIsRedactedFirst() {
+        // A short secret that is a prefix of a longer one must not leave the
+        // longer one's tail exposed.
+        let short = SecretValue("sk-live")
+        let long = SecretValue("sk-live-full-token")
+
+        let redacted = Redactor.redact("here is sk-live-full-token", using: [short, long])
+
+        XCTAssertFalse(redacted.contains("full-token"), "got: \(redacted)")
+    }
+
+    func testVeryShortSecretsAreNotRedacted() {
+        // Redacting "ab" would blank out ordinary words and hide the error the
+        // user needs to read, while protecting nothing worth protecting.
+        let redacted = Redactor.redact("a table of absolute values", using: [SecretValue("ab")])
+        XCTAssertEqual(redacted, "a table of absolute values")
+    }
+
+    func testRedactionWithNothingToRedact() {
+        XCTAssertEqual(Redactor.redact("plain output", using: []), "plain output")
+        XCTAssertEqual(Redactor.redact("", using: [SecretValue("sk-live-abcdef")]), "")
+    }
+}

--- a/Cai/CaiTests/SecretStoreTests.swift
+++ b/Cai/CaiTests/SecretStoreTests.swift
@@ -68,6 +68,39 @@ final class SecretStoreTests: XCTestCase {
         XCTAssertEqual(SecretStore.value(for: testName)?.raw, "")
     }
 
+    func testAPastedTrailingNewlineIsTrimmedAtSave() {
+        // pbcopy and terminal copies routinely append one. Stored verbatim it
+        // breaks auth and defeats redaction (echoed output has no newline, so
+        // the stored raw never matches).
+        SecretStore.save("sk-live-abc\n", name: testName)
+        XCTAssertEqual(SecretStore.value(for: testName)?.raw, "sk-live-abc")
+
+        SecretStore.save("  sk-live-abc  \n", name: testName)
+        XCTAssertEqual(SecretStore.value(for: testName)?.raw, "sk-live-abc", "ends trimmed")
+
+        SecretStore.save("line1\nline2", name: testName)
+        XCTAssertEqual(SecretStore.value(for: testName)?.raw, "line1\nline2", "interior newlines stay, PEM-style material is legitimate")
+    }
+
+    // MARK: - Lookup preserves the failure mode
+
+    func testLookupDistinguishesMissingFromFound() {
+        XCTAssertEqual(SecretStore.lookup(testName), .missing)
+        SecretStore.save("v", name: testName)
+        XCTAssertEqual(SecretStore.lookup(testName), .found(SecretValue("v")))
+    }
+
+    func testResolveThrowsUnknownSecretForAMissingName() {
+        do {
+            _ = try SecretStore.resolve([testName])
+            XCTFail("resolved a missing secret")
+        } catch TemplateEngine.FilterError.unknownSecret(let name) {
+            XCTAssertEqual(name, testName)
+        } catch {
+            XCTFail("wrong error: \(error)")
+        }
+    }
+
     // MARK: - Enumeration
 
     func testTheListReportsNamesAndDatesWithoutValues() throws {
@@ -105,7 +138,7 @@ final class SecretStoreTests: XCTestCase {
     // MARK: - Resolution for a shell command
 
     func testATemplateWithoutSecretsChangesNothing() throws {
-        let prepared = try SecretStore.prepareForShell(template: "echo {{result}}")
+        let prepared = try SecretStore.prepareForShell(template: "echo {{result}} {{API_KEY}}")
 
         XCTAssertTrue(prepared.isEmpty)
         XCTAssertNil(prepared.access, "no access means the engine keeps refusing")
@@ -115,7 +148,7 @@ final class SecretStoreTests: XCTestCase {
     func testPreparationPutsTheValueInTheEnvironment() throws {
         SecretStore.save("sk-live-xyz", name: testName)
 
-        let prepared = try SecretStore.prepareForShell(template: "curl -H \"Bearer {{\(testName)}}\"")
+        let prepared = try SecretStore.prepareForShell(template: "curl -H \"Bearer {{secrets.\(testName)}}\"")
 
         XCTAssertEqual(prepared.environment?["CAI_SECRET_\(testName)"], "sk-live-xyz")
         XCTAssertNotNil(prepared.environment?["PATH"], "the Homebrew PATH must survive")
@@ -124,13 +157,25 @@ final class SecretStoreTests: XCTestCase {
 
     func testPreparationFailsOnAMissingSecret() {
         do {
-            _ = try SecretStore.prepareForShell(template: "echo {{ZZ_CAI_TEST_ABSENT}}")
+            _ = try SecretStore.prepareForShell(template: "echo {{secrets.ZZ_CAI_TEST_ABSENT}}")
             XCTFail("a missing secret was resolved to nothing")
         } catch TemplateEngine.FilterError.unknownSecret(let name) {
             XCTAssertEqual(name, "ZZ_CAI_TEST_ABSENT")
         } catch {
             XCTFail("wrong error: \(error)")
         }
+    }
+
+    func testPreparationFollowsTheEngineNotTheScanner() throws {
+        // The quoted-`}}` template where the two parsers disagree: the engine
+        // treats {{secrets.…}} inside the llm arg as literal text, so no
+        // environment may be built for it, even though the scanner over-reports.
+        SecretStore.save("v", name: testName)
+
+        let template = "{{result|llm:\"see }} {{secrets.\(testName)}} docs\"}}"
+        let prepared = try SecretStore.prepareForShell(template: template)
+
+        XCTAssertTrue(prepared.isEmpty, "a secret was handed to a command that never references it")
     }
 
     // MARK: - Redaction


### PR DESCRIPTION
Named secrets for shell actions: store a token once in the Keychain, reference it as `{{secrets.NAME}}` (GitHub Actions spelling), and Cai injects it into the command's environment at execution time. The value never enters the rendered command, the model, logs, or history; output is redacted afterwards as a last line of defence.

Prompts and every other sink refuse secret references by default and fail loud, never silently empty. Missing secrets, locked Keychain, and references inside single quotes each get their own clear error.

Core only: no Settings UI yet (next PR, together with the approval-sheet callout), and webhook support is deliberately deferred so it can land fail-closed with its call site. Covered by four test suites including a real-subprocess end-to-end check.