### PR TITLE
feat: manage secrets in Settings, with shell import and agent name references

### DIFF
--- a/Cai/Cai/Services/ActionsSnapshotPublisher.swift
+++ b/Cai/Cai/Services/ActionsSnapshotPublisher.swift
@@ -68,6 +68,14 @@ final class ActionsSnapshotPublisher {
             actions: known.shortcuts,
             destinations: known.destinations,
             builtInActionNames: known.builtInActionNames,
+            // Names only — so an agent references the secret the user actually
+            // stored. Gated on the kill switch: when authoring is off the agent
+            // can't act, so names don't leave the app at all (flipping the
+            // switch republishes, so they come back on enable). `list()` sorts
+            // and drops the values; it also maps a locked Keychain to empty, so
+            // a republish while locked briefly omits the names until the next
+            // one — transient and self-healing.
+            secretNames: settings.allowAgentProposals ? SecretStore.list().map(\.name) : [],
             agentAuthoringEnabled: settings.allowAgentProposals
         )
 

--- a/Cai/Cai/Services/SecretStore.swift
+++ b/Cai/Cai/Services/SecretStore.swift
@@ -189,6 +189,13 @@ enum SecretStore {
         // redaction, since echoed output carries the token without the newline.
         // Interior whitespace stays: PEM-style material is legitimate.
         let value = value.trimmingCharacters(in: .whitespacesAndNewlines)
+        // An empty value stores fine (`"".data(using:)` is non-nil) but then
+        // hands a blank credential to the command at run time, failing far away
+        // with the wrong error. Refuse it here so both the form and the shell
+        // import (a `FOO=` entry) stop at the source.
+        guard !value.isEmpty else {
+            return .invalidName("A secret can't be empty.")
+        }
         guard let data = value.data(using: .utf8) else {
             return .invalidName("That value cannot be stored as text.")
         }

--- a/Cai/Cai/Services/SecretStore.swift
+++ b/Cai/Cai/Services/SecretStore.swift
@@ -47,8 +47,18 @@ enum SecretStore {
 
     // MARK: - Reading
 
-    /// Every stored secret, name and dates only, sorted by name.
-    static func list() -> [SecretDescriptor] {
+    enum ListResult: Equatable {
+        case items([SecretDescriptor])
+        /// The Keychain refused enumeration (locked at wake, ACL mismatch).
+        /// The Secrets screen shows its unavailable banner for this — showing
+        /// "No secrets yet" over a locked keychain invites the user to
+        /// overwrite every secret they own.
+        case unavailable(OSStatus)
+    }
+
+    /// Every stored secret, name and dates only, sorted by name — or why the
+    /// Keychain would not say.
+    static func enumerate() -> ListResult {
         let query: [String: Any] = [
             kSecClass as String: kSecClassGenericPassword,
             kSecAttrService as String: service,
@@ -58,12 +68,17 @@ enum SecretStore {
         ]
 
         var result: AnyObject?
-        guard SecItemCopyMatching(query as CFDictionary, &result) == errSecSuccess,
-              let items = result as? [[String: Any]] else {
-            return []
+        let status = SecItemCopyMatching(query as CFDictionary, &result)
+        // Zero matching items reports as errSecItemNotFound, which is an
+        // empty store, not a refusal.
+        guard status == errSecSuccess || status == errSecItemNotFound else {
+            return .unavailable(status)
+        }
+        guard let items = result as? [[String: Any]] else {
+            return .items([])
         }
 
-        return items.compactMap { attributes -> SecretDescriptor? in
+        let descriptors = items.compactMap { attributes -> SecretDescriptor? in
             guard let account = attributes[kSecAttrAccount as String] as? String,
                   let name = SecretReference.name(fromAccount: account) else {
                 return nil  // the model API keys share this service
@@ -75,6 +90,14 @@ enum SecretStore {
             )
         }
         .sorted { $0.name < $1.name }
+        return .items(descriptors)
+    }
+
+    /// Convenience for callers that treat a refusing Keychain as empty
+    /// (`exists`, counts). Anything user-facing goes through `enumerate()`.
+    static func list() -> [SecretDescriptor] {
+        if case .items(let items) = enumerate() { return items }
+        return []
     }
 
     static func exists(_ name: String) -> Bool {

--- a/Cai/Cai/Services/ShellEnvCapture.swift
+++ b/Cai/Cai/Services/ShellEnvCapture.swift
@@ -1,0 +1,165 @@
+import CaiActionCore
+import Foundation
+
+/// Reads the user's login-shell environment once, on demand, for the
+/// "Import from shell…" flow in Settings → Secrets.
+///
+/// GUI apps inherit nothing from the terminal, and `zsh -c` sources only
+/// `~/.zshenv`, so the tokens people actually export (in `.zshrc`,
+/// `.bash_profile`, fish config) are invisible to Cai without this. The
+/// capture is the VS Code pattern: spawn the user's own login shell
+/// interactively, print the environment, parse, discard.
+///
+/// ```
+/// getpwuid(getuid()).pw_shell ─▶ ShellRunner.run(executable: shell, flags: "-ilc",
+///         │ (never $SHELL env —        "printf '\0CAI_ENV\0'; /usr/bin/env -0")
+///         │  GUI apps don't have it)          │ 10s timeout
+///         │ exec fails ─▶ retry /bin/zsh      ▼
+///         └───────────────────▶ split stdout on the marker, parse NUL-separated
+///                               KEY=VALUE after it (rc noise prints before it)
+///                                       ─▶ filter ─▶ [Candidate]
+/// ```
+///
+/// Everything this captures is secret material: parsed, filtered, handed to
+/// `SecretStore.save` for the names the user ticks, and never logged or
+/// retained past the import sheet.
+enum ShellEnvCapture {
+
+    /// Printed by the shell before `env -0` so rc noise (motd, echoes from
+    /// `.zshrc`) can be discarded without guessing. NUL cannot appear in rc
+    /// noise by accident: it terminates C strings, so shells don't emit it.
+    static let marker = "\u{0}CAI_ENV\u{0}"
+
+    /// One importable environment variable. The value is carried for the save
+    /// and never displayed; `replacesExisting` drives the row's orange tag.
+    struct Candidate: Equatable {
+        let name: String
+        let value: SecretValue
+        let replacesExisting: Bool
+        /// Token-shaped names (`*_TOKEN`, `*_KEY`, `*_SECRET`, `*API*`) sort
+        /// before the rest, which collapse under "Show all".
+        let looksLikeToken: Bool
+    }
+
+    /// Env-var names that pass the secret-name shape but are never
+    /// credentials. Excluded outright rather than down-ranked: offering PATH
+    /// as an importable secret erodes trust in the whole list.
+    static let noise: Set<String> = [
+        "PATH", "HOME", "SHELL", "USER", "LOGNAME", "TMPDIR", "PWD", "OLDPWD",
+        "TERM", "TERM_PROGRAM", "TERM_PROGRAM_VERSION", "TERM_SESSION_ID",
+        "LANG", "LC_ALL", "LC_CTYPE", "EDITOR", "VISUAL", "PAGER", "MANPATH",
+        "DISPLAY", "COLORTERM", "SHLVL", "HOSTNAME", "INFOPATH",
+        "XPC_FLAGS", "XPC_SERVICE_NAME", "SSH_AUTH_SOCK", "HOMEBREW_PREFIX",
+        "HOMEBREW_CELLAR", "HOMEBREW_REPOSITORY", "ZDOTDIR", "OSTYPE",
+    ]
+
+    private static let tokenMarkers = ["TOKEN", "KEY", "SECRET", "API", "PASSWORD", "CREDENTIAL"]
+
+    /// The user's login shell from the user record. The `SHELL` environment
+    /// variable is the wrong source here: launchd-spawned GUI apps don't
+    /// reliably carry it.
+    static func loginShell() -> String {
+        if let passwd = getpwuid(getuid()), let shell = passwd.pointee.pw_shell {
+            let path = String(cString: shell)
+            if !path.isEmpty { return path }
+        }
+        return "/bin/zsh"
+    }
+
+    /// Runs the capture. Returns candidates, or throws the error whose
+    /// message the import sheet's failure state shows.
+    ///
+    /// `-ilc` is interactive + login so both `.zshrc`-style (interactive) and
+    /// `.zprofile`/`.bash_profile`-style (login) exports are sourced; fish
+    /// accepts the same flags. A shell that rejects the flags or is missing
+    /// falls back to plain zsh — worse coverage, never a dead end.
+    static func capture() async throws -> [Candidate] {
+        let command = "printf '\\0CAI_ENV\\0'; /usr/bin/env -0"
+        let existing = Set(SecretStore.list().map(\.name))
+
+        var output: ShellRunner.Output
+        do {
+            output = try await ShellRunner.run(
+                command, stdin: "", timeout: captureTimeout,
+                executable: loginShell(), flags: "-ilc"
+            )
+        } catch {
+            // Exotic or missing login shell (csh rejects -ilc, chsh to a
+            // deleted binary): retry with the shell every Mac has.
+            output = try await ShellRunner.run(
+                command, stdin: "", timeout: captureTimeout,
+                executable: "/bin/zsh", flags: "-ilc"
+            )
+        }
+        if output.timedOut {
+            throw CaptureError.timedOut
+        }
+        guard output.status == 0 else {
+            throw CaptureError.shellFailed(status: output.status)
+        }
+        guard output.stdout.contains(marker) else {
+            // The shell ran but our command never printed: an rc file that
+            // exec's something else, or output swallowed. An error, not an
+            // empty candidate list — "no variables found" would be a lie.
+            throw CaptureError.markerMissing
+        }
+        return candidates(fromCaptureOutput: output.stdout, existing: existing)
+    }
+
+    static let captureTimeout: TimeInterval = 10
+
+    enum CaptureError: LocalizedError, Equatable {
+        case timedOut
+        case shellFailed(status: Int32)
+        case markerMissing
+
+        var errorDescription: String? {
+            switch self {
+            case .timedOut:
+                return "Your shell took more than \(Int(ShellEnvCapture.captureTimeout)) seconds to start."
+            case .shellFailed(let status):
+                return "Your shell exited with code \(status) before printing its environment."
+            case .markerMissing:
+                return "Your shell's output couldn't be read."
+            }
+        }
+    }
+
+    /// Pure parse + filter, table-tested without a subprocess.
+    ///
+    /// Everything before the marker is rc noise and dropped. After it, entries
+    /// are NUL-separated `KEY=VALUE`; `-0` is what lets multiline values
+    /// survive. Entries without `=`, names that fail the secret shape, and the
+    /// noise list are skipped. Token-shaped names sort first, then
+    /// alphabetically within each group.
+    static func candidates(fromCaptureOutput output: String, existing: Set<String>) -> [Candidate] {
+        guard let markerRange = output.range(of: marker) else { return [] }
+        let payload = output[markerRange.upperBound...]
+
+        var found: [Candidate] = []
+        var seen: Set<String> = []
+        for entry in payload.split(separator: "\u{0}", omittingEmptySubsequences: true) {
+            guard let equals = entry.firstIndex(of: "=") else { continue }
+            let name = String(entry[..<equals])
+            let value = String(entry[entry.index(after: equals)...])
+
+            guard SecretReference.isValidName(name),
+                  !noise.contains(name),
+                  !name.hasPrefix(SecretReference.environmentPrefix),
+                  !seen.contains(name) else { continue }
+            seen.insert(name)
+
+            found.append(Candidate(
+                name: name,
+                value: SecretValue(value),
+                replacesExisting: existing.contains(name),
+                looksLikeToken: tokenMarkers.contains { name.contains($0) }
+            ))
+        }
+
+        return found.sorted {
+            if $0.looksLikeToken != $1.looksLikeToken { return $0.looksLikeToken }
+            return $0.name < $1.name
+        }
+    }
+}

--- a/Cai/Cai/Services/ShellEnvCapture.swift
+++ b/Cai/Cai/Services/ShellEnvCapture.swift
@@ -77,19 +77,22 @@ enum ShellEnvCapture {
         let command = "printf '\\0CAI_ENV\\0'; /usr/bin/env -0"
         let existing = Set(SecretStore.list().map(\.name))
 
-        var output: ShellRunner.Output
-        do {
-            output = try await ShellRunner.run(
-                command, stdin: "", timeout: captureTimeout,
-                executable: loginShell(), flags: "-ilc"
-            )
-        } catch {
-            // Exotic or missing login shell (csh rejects -ilc, chsh to a
-            // deleted binary): retry with the shell every Mac has.
-            output = try await ShellRunner.run(
-                command, stdin: "", timeout: captureTimeout,
-                executable: "/bin/zsh", flags: "-ilc"
-            )
+        let shell = loginShell()
+        var output = await attempt(command, shell: shell)
+
+        // The login shell can fail short of throwing, and the original catch
+        // only saw exec failure (a missing binary). csh/tcsh spawn fine but
+        // reject `-ilc` and exit non-zero; an rc file can swallow the command
+        // so the marker never prints; the shell can hang past the timeout.
+        // `attempt` returns nil only on exec failure. Any unusable result
+        // falls back to the shell every Mac has, unless we already ran it.
+        if !(output.map(Self.isUsable) ?? false), shell != fallbackShell {
+            output = await attempt(command, shell: fallbackShell)
+        }
+
+        guard let output else {
+            // Neither the login shell nor /bin/zsh could be launched at all.
+            throw CaptureError.shellUnavailable
         }
         if output.timedOut {
             throw CaptureError.timedOut
@@ -103,15 +106,44 @@ enum ShellEnvCapture {
             // empty candidate list — "no variables found" would be a lie.
             throw CaptureError.markerMissing
         }
+        guard !output.truncated else {
+            // A >10 MB environment was capped mid-stream: the last record is a
+            // fragment and everything past the cap is gone. Importing from a
+            // truncated capture would save a mangled credential, so refuse the
+            // whole capture rather than offer a corrupted candidate.
+            throw CaptureError.outputTooLarge
+        }
         return candidates(fromCaptureOutput: output.stdout, existing: existing)
     }
 
+    /// One capture attempt. Returns nil only when the shell binary can't be
+    /// launched — the sole failure `ShellRunner.run` throws for. A shell that
+    /// spawns and then fails still returns its `Output`, so the caller can tell
+    /// "wrong shell" (retry zsh) from "no shell at all".
+    private static func attempt(_ command: String, shell: String) async -> ShellRunner.Output? {
+        try? await ShellRunner.run(
+            command, stdin: "", timeout: captureTimeout,
+            executable: shell, flags: "-ilc"
+        )
+    }
+
+    /// A capture worth keeping: exited cleanly and printed the marker. A
+    /// truncated-but-marked capture is still "usable" here — truncation isn't
+    /// the shell's fault and retrying zsh would truncate too; `capture()`
+    /// rejects it separately.
+    private static func isUsable(_ output: ShellRunner.Output) -> Bool {
+        !output.timedOut && output.status == 0 && output.stdout.contains(marker)
+    }
+
     static let captureTimeout: TimeInterval = 10
+    static let fallbackShell = "/bin/zsh"
 
     enum CaptureError: LocalizedError, Equatable {
         case timedOut
         case shellFailed(status: Int32)
         case markerMissing
+        case outputTooLarge
+        case shellUnavailable
 
         var errorDescription: String? {
             switch self {
@@ -121,6 +153,10 @@ enum ShellEnvCapture {
                 return "Your shell exited with code \(status) before printing its environment."
             case .markerMissing:
                 return "Your shell's output couldn't be read."
+            case .outputTooLarge:
+                return "Your shell environment is too large to read safely."
+            case .shellUnavailable:
+                return "Cai couldn't start your shell or /bin/zsh."
             }
         }
     }

--- a/Cai/Cai/Services/ShellRunner.swift
+++ b/Cai/Cai/Services/ShellRunner.swift
@@ -71,6 +71,12 @@ enum ShellRunner {
         /// by signal too and used to be misreported as "exceeded 60s".
         let timedOut: Bool
 
+        /// stdout and/or stderr hit `maxOutputBytes` and were capped. The
+        /// surviving text carries `truncationMarker`, but a caller that parses
+        /// the stream (ShellEnvCapture) needs the flag, not the marker text, to
+        /// know its last record may be a fragment.
+        let truncated: Bool
+
         /// stdout with surrounding whitespace removed, which is what every
         /// caller that propagates output actually wants.
         var trimmedStdout: String {
@@ -189,7 +195,8 @@ enum ShellRunner {
             status: process.terminationStatus,
             stdout: stdout,
             stderr: stderr,
-            timedOut: timedOut
+            timedOut: timedOut,
+            truncated: outTruncated || errTruncated
         )
     }
 

--- a/Cai/Cai/Services/ShellRunner.swift
+++ b/Cai/Cai/Services/ShellRunner.swift
@@ -102,11 +102,17 @@ enum ShellRunner {
         stdin: String,
         environment: [String: String]? = nil,
         mergeStderrIntoStdout: Bool = false,
-        timeout: TimeInterval = defaultTimeout
+        timeout: TimeInterval = defaultTimeout,
+        executable: String = "/bin/zsh",
+        flags: String = "-c"
     ) async throws -> Output {
+        // `executable`/`flags` exist for ShellEnvCapture, which runs the user's
+        // own login shell (`$SHELL -ilc …`). Every other caller wants the
+        // defaults; a second Process wrapper would re-meet the SIGPIPE,
+        // pool-starvation and waitUntilExit traps documented below.
         let process = Process()
-        process.executableURL = URL(fileURLWithPath: "/bin/zsh")
-        process.arguments = ["-c", command]
+        process.executableURL = URL(fileURLWithPath: executable)
+        process.arguments = [flags, command]
         process.environment = environment ?? OutputDestinationService.shellEnvironment()
 
         let inputPipe = Pipe()

--- a/Cai/Cai/Services/TemplateEngine.swift
+++ b/Cai/Cai/Services/TemplateEngine.swift
@@ -91,7 +91,7 @@ struct TemplateEngine {
             case .secretNotAllowed(let name):
                 return "{{secrets.\(name)}} can't be used here. Secrets work only in shell commands for now."
             case .unknownSecret(let name):
-                return "No secret named \(name) is stored on this Mac."
+                return "No secret named \(name) is stored on this Mac. Add it in Settings → Secrets."
             case .secretThroughFilter(let name, let filter):
                 return "{{secrets.\(name)}} can't go through |\(filter). Filters could move the value somewhere Cai can't protect."
             case .keychainUnavailable(let status):

--- a/Cai/Cai/Views/ActionListWindow.swift
+++ b/Cai/Cai/Views/ActionListWindow.swift
@@ -53,6 +53,7 @@ struct ActionListWindow: View {
     @State private var showDestinationsManagement: Bool = false
     @State private var showExtensionBrowser: Bool = false
     @State private var showConnectors: Bool = false
+    @State private var showSecretsManagement: Bool = false
     /// Which tab the MCP screen opens on. Settings opens Server (the release
     /// headline); the missing-credentials redirect opens Client, because that
     /// user was sent here to enter an API key.
@@ -96,6 +97,7 @@ struct ActionListWindow: View {
         if showExtensionConfirm { return .extensionConfirm }
         if showMCPForm { return .mcpForm }
         if showConnectors { return .connectors }
+        if showSecretsManagement { return .secretsManagement }
         if showExtensionBrowser { return .extensionBrowser }
         if showDestinationsManagement { return .destinationsManagement }
         if showShortcutsManagement { return .shortcutsManagement }
@@ -107,7 +109,7 @@ struct ActionListWindow: View {
     }
 
     private enum Screen {
-        case actions, result, settings, history, customPrompt, shortcutsManagement, destinationsManagement, extensionBrowser, extensionConfirm, mcpForm, connectors
+        case actions, result, settings, history, customPrompt, shortcutsManagement, destinationsManagement, extensionBrowser, extensionConfirm, mcpForm, connectors, secretsManagement
     }
 
     /// Actions to display — when filtering, merges built-in actions + user shortcuts,
@@ -176,6 +178,7 @@ struct ActionListWindow: View {
             .onChange(of: showDestinationsManagement) { updateFilterInputFlag() }
             .onChange(of: showMCPForm) { updateFilterInputFlag() }
             .onChange(of: showConnectors) { updateFilterInputFlag() }
+            .onChange(of: showSecretsManagement) { updateFilterInputFlag() }
             .onChange(of: showExtensionConfirm) { updateFilterInputFlag() }
             .onChange(of: showFollowUpInput) { updateFilterInputFlag() }
             .onAppear {
@@ -253,6 +256,7 @@ struct ActionListWindow: View {
                     showExtensionConfirm = false
                     showMCPForm = false
                     showConnectors = false
+                    showSecretsManagement = false
                     activeMCPActionConfig = nil
                     withAnimation(.easeInOut(duration: 0.15)) {
                         showSettings = true
@@ -310,6 +314,13 @@ struct ActionListWindow: View {
         } else if showConnectors {
             withAnimation(.easeInOut(duration: 0.15)) {
                 showConnectors = false
+                showSettings = true
+            }
+        } else if showSecretsManagement {
+            // Esc closes an open add/import form first, the screen second.
+            if SecretsManagementView.escInterceptor?() == true { return }
+            withAnimation(.easeInOut(duration: 0.15)) {
+                showSecretsManagement = false
                 showSettings = true
             }
         } else if showExtensionBrowser {
@@ -716,6 +727,12 @@ struct ActionListWindow: View {
                     withAnimation(.easeInOut(duration: 0.15)) {
                         showSettings = false
                         showConnectors = true
+                    }
+                },
+                onShowSecrets: {
+                    withAnimation(.easeInOut(duration: 0.15)) {
+                        showSettings = false
+                        showSecretsManagement = true
                     }
                 },
                 onShowModelSetup: {
@@ -1536,6 +1553,15 @@ struct ActionListWindow: View {
                     }
                 },
                 initialTab: connectorsInitialTab
+            )
+        } else if showSecretsManagement {
+            SecretsManagementView(
+                onBack: {
+                    withAnimation(.easeInOut(duration: 0.15)) {
+                        showSecretsManagement = false
+                        showSettings = true
+                    }
+                }
             )
         } else if showShortcutsManagement {
             ActionsManagementView(

--- a/Cai/Cai/Views/ActionReviewPresentation.swift
+++ b/Cai/Cai/Views/ActionReviewPresentation.swift
@@ -27,7 +27,13 @@ enum ActionReviewPresentation {
     // MARK: - Escalation copy
 
     /// The plain-language warning shown under the payload, one per reason.
-    static func callout(for reason: EscalationReason) -> String {
+    ///
+    /// `secretNames` is scanned from the proposal's template at render time
+    /// (never taken from the stored validation — CAI-25), so a
+    /// `referencesSecrets` callout names exactly what the payload on screen
+    /// reaches for. Empty names still warn, just generically: a chained action
+    /// can carry the reason while the proposal's own text has no reference.
+    static func callout(for reason: EscalationReason, secretNames: [String] = []) -> String {
         switch reason {
         case .runsShellCommands:
             return "This action can run terminal commands on your Mac."
@@ -39,7 +45,20 @@ enum ActionReviewPresentation {
             return "This action runs without showing its output."
         case .chainsToUnknownAction:
             return "This action triggers another action that doesn't exist yet, so Cai can't say what it will do."
+        case .referencesSecrets:
+            guard !secretNames.isEmpty else {
+                return "This action uses one of your secrets."
+            }
+            let noun = secretNames.count == 1 ? "secret" : "secrets"
+            return "This action uses your \(noun) \(secretList(secretNames))."
         }
+    }
+
+    /// "A" / "A and B" / "A, B and C" — names only, never values.
+    static func secretList(_ names: [String]) -> String {
+        let sorted = names.sorted()
+        guard sorted.count > 1 else { return sorted.first ?? "" }
+        return sorted.dropLast().joined(separator: ", ") + " and " + sorted[sorted.count - 1]
     }
 
     /// Lead-in for the grouped callout, used when an action carries more than
@@ -49,7 +68,7 @@ enum ActionReviewPresentation {
     /// One risk as a list item, for the grouped callout. Same claim as the
     /// sentence form, minus the repeated "This action" that reads as noise
     /// once it is stacked three deep.
-    static func calloutBullet(for reason: EscalationReason) -> String {
+    static func calloutBullet(for reason: EscalationReason, secretNames: [String] = []) -> String {
         switch reason {
         case .runsShellCommands:
             return "Run terminal commands on your Mac"
@@ -61,6 +80,10 @@ enum ActionReviewPresentation {
             return "Run without showing its output"
         case .chainsToUnknownAction:
             return "Trigger another action that doesn't exist yet"
+        case .referencesSecrets:
+            guard !secretNames.isEmpty else { return "Use one of your secrets" }
+            let noun = secretNames.count == 1 ? "secret" : "secrets"
+            return "Use your \(noun) \(secretList(secretNames))"
         }
     }
 
@@ -73,14 +96,17 @@ enum ActionReviewPresentation {
         case grouped(header: String, bullets: [String])
     }
 
-    static func callout(for reasons: [EscalationReason]) -> Callout {
+    static func callout(for reasons: [EscalationReason], secretNames: [String] = []) -> Callout {
         switch reasons.count {
         case 0:
             return .none
         case 1:
-            return .sentence(callout(for: reasons[0]))
+            return .sentence(callout(for: reasons[0], secretNames: secretNames))
         default:
-            return .grouped(header: calloutHeader, bullets: reasons.map(calloutBullet))
+            return .grouped(
+                header: calloutHeader,
+                bullets: reasons.map { calloutBullet(for: $0, secretNames: secretNames) }
+            )
         }
     }
 

--- a/Cai/Cai/Views/ActionReviewView.swift
+++ b/Cai/Cai/Views/ActionReviewView.swift
@@ -172,7 +172,7 @@ struct ActionReviewView: View {
                 chainBlock(for: validated.after)
             }
 
-            callout(for: validated.escalationReasons)
+            callout(for: validated.escalationReasons, in: validated.after)
 
             metadata(for: proposal)
 
@@ -314,8 +314,14 @@ struct ActionReviewView: View {
     /// "This action" down the sheet and pushes the buttons off the fold, so
     /// two or more collapse into a single headed list.
     @ViewBuilder
-    private func callout(for reasons: [EscalationReason]) -> some View {
-        switch ActionReviewPresentation.callout(for: reasons) {
+    private func callout(for reasons: [EscalationReason], in action: ActionSnapshot) -> some View {
+        // Names are scanned from the payload on screen at render time, never
+        // read from the stored validation (CAI-25): what the callout claims is
+        // exactly what the text the user is reading reaches for.
+        switch ActionReviewPresentation.callout(
+            for: reasons,
+            secretNames: Array(SecretReference.names(in: action.value))
+        ) {
         case .none:
             EmptyView()
 

--- a/Cai/Cai/Views/ManagementScreen.swift
+++ b/Cai/Cai/Views/ManagementScreen.swift
@@ -49,9 +49,13 @@ struct ManagementScreen<Tab: Hashable, Content: View>: View {
             header
             Divider().background(Color.caiDivider)
 
-            TabBar(selection: $selection, tabs: tabs)
-                .padding(.horizontal, 16)
-                .padding(.vertical, 8)
+            // Single-list screens (Secrets) pass no tabs: a one-pill TabBar is
+            // noise, so the content sits directly under the header.
+            if !tabs.isEmpty {
+                TabBar(selection: $selection, tabs: tabs)
+                    .padding(.horizontal, 16)
+                    .padding(.vertical, 8)
+            }
 
             content()
 
@@ -82,8 +86,9 @@ struct ManagementScreen<Tab: Hashable, Content: View>: View {
             // `+` only on the configured custom tab. Always visible there
             // (even while editing) so the user can interrupt and start a
             // fresh add — caller's `onAdd` is responsible for cancelling
-            // any in-progress form first.
-            if let customTabId, let onAdd, selection == customTabId {
+            // any in-progress form first. Tab-less screens have no gate:
+            // `onAdd` alone shows it.
+            if let onAdd, tabs.isEmpty || (customTabId != nil && selection == customTabId) {
                 Button(action: onAdd) {
                     Image(systemName: "plus.circle.fill")
                         .font(.system(size: 16, weight: .medium))
@@ -124,6 +129,12 @@ struct ManagementEmptyState: View {
     var ctaLabel: String? = nil
     var ctaIcon: String? = nil
     var ctaAction: (() -> Void)? = nil
+    /// Optional second CTA, same neutral vocabulary. Deliberately rare: the
+    /// Secrets empty state is the one screen where two next steps (add,
+    /// import) genuinely compete for the first click.
+    var secondaryCtaLabel: String? = nil
+    var secondaryCtaIcon: String? = nil
+    var secondaryCtaAction: (() -> Void)? = nil
 
     var body: some View {
         VStack(spacing: 12) {
@@ -144,32 +155,43 @@ struct ManagementEmptyState: View {
                     .padding(.horizontal, 24)
             }
 
-            if let ctaLabel, let ctaAction {
-                Button(action: ctaAction) {
-                    HStack(spacing: 4) {
-                        if let ctaIcon {
-                            Image(systemName: ctaIcon)
-                                .font(.system(size: 10, weight: .medium))
-                        }
-                        Text(ctaLabel)
-                            .font(.system(size: 11, weight: .medium))
+            if ctaAction != nil || secondaryCtaAction != nil {
+                HStack(spacing: 8) {
+                    if let ctaLabel, let ctaAction {
+                        ctaButton(label: ctaLabel, icon: ctaIcon, action: ctaAction)
                     }
-                    .foregroundColor(.caiTextSecondary)
-                    .padding(.horizontal, 10)
-                    .padding(.vertical, 5)
-                    .background(
-                        RoundedRectangle(cornerRadius: 5)
-                            .fill(Color.caiSurface.opacity(0.6))
-                    )
-                    .overlay(
-                        RoundedRectangle(cornerRadius: 5)
-                            .strokeBorder(Color.caiDivider.opacity(0.5), lineWidth: 0.5)
-                    )
+                    if let secondaryCtaLabel, let secondaryCtaAction {
+                        ctaButton(label: secondaryCtaLabel, icon: secondaryCtaIcon, action: secondaryCtaAction)
+                    }
                 }
-                .buttonStyle(.plain)
             }
         }
         .frame(maxWidth: .infinity, minHeight: 120)
         .padding(.vertical, 24)
+    }
+
+    private func ctaButton(label: String, icon: String?, action: @escaping () -> Void) -> some View {
+        Button(action: action) {
+            HStack(spacing: 4) {
+                if let icon {
+                    Image(systemName: icon)
+                        .font(.system(size: 10, weight: .medium))
+                }
+                Text(label)
+                    .font(.system(size: 11, weight: .medium))
+            }
+            .foregroundColor(.caiTextSecondary)
+            .padding(.horizontal, 10)
+            .padding(.vertical, 5)
+            .background(
+                RoundedRectangle(cornerRadius: 5)
+                    .fill(Color.caiSurface.opacity(0.6))
+            )
+            .overlay(
+                RoundedRectangle(cornerRadius: 5)
+                    .strokeBorder(Color.caiDivider.opacity(0.5), lineWidth: 0.5)
+            )
+        }
+        .buttonStyle(.plain)
     }
 }

--- a/Cai/Cai/Views/SecretFormView.swift
+++ b/Cai/Cai/Views/SecretFormView.swift
@@ -15,7 +15,6 @@ struct SecretFormView: View {
 
     @State private var name: String = ""
     @State private var value: String = ""
-    @State private var strippedLineBreaks = false
     @State private var saveFailure: String?
     @FocusState private var focus: Field?
     private enum Field { case name, value }
@@ -140,12 +139,6 @@ struct SecretFormView: View {
                 .font(.system(size: 12, design: .monospaced))
                 .focused($focus, equals: .value)
                 .accessibilityLabel("Secret value, hidden")
-                .onChange(of: value) { _, new in
-                    if new.contains(where: \.isNewline) {
-                        value = new.filter { !$0.isNewline }
-                        strippedLineBreaks = true
-                    }
-                }
                 .onSubmit { save() }
                 .padding(.horizontal, 8)
                 .padding(.vertical, 6)
@@ -167,13 +160,25 @@ struct SecretFormView: View {
                     .foregroundColor(.caiTextSecondary.opacity(0.7))
                     .monospacedDigit()
                     .accessibilityLabel("\(value.count) characters entered")
-                if strippedLineBreaks {
-                    Text("Line breaks removed")
+                if valueHasLineBreaks {
+                    // Block, don't silently strip: a stray interior newline (a
+                    // wrapped paste) would corrupt a single-line token, and a
+                    // real multiline secret (a PEM key) belongs in shell import,
+                    // which stores it intact. A trailing newline is trimmed at
+                    // save, so only interior breaks block.
+                    Text("Remove the line breaks — a secret is a single line.")
                         .font(.system(size: 11))
-                        .foregroundColor(.caiTextSecondary.opacity(0.7))
+                        .foregroundColor(.caiError)
+                        .accessibilityLabel("Remove the line breaks. A secret is a single line.")
                 }
             }
         }
+    }
+
+    /// An interior newline (after trimming the edges save() trims anyway). A
+    /// pasted single-line token with a wrapped break, not a legitimate one.
+    private var valueHasLineBreaks: Bool {
+        value.trimmingCharacters(in: .whitespacesAndNewlines).contains(where: \.isNewline)
     }
 
     // MARK: - Save
@@ -181,6 +186,8 @@ struct SecretFormView: View {
     private var canSave: Bool {
         let effective = replacingName ?? name
         return SecretReference.isValidName(effective)
+            && !value.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+            && !valueHasLineBreaks
     }
 
     private var buttons: some View {

--- a/Cai/Cai/Views/SecretFormView.swift
+++ b/Cai/Cai/Views/SecretFormView.swift
@@ -1,0 +1,228 @@
+import CaiActionCore
+import SwiftUI
+
+/// Add or replace one secret. Write-only from the first keystroke: the value
+/// field is a `SecureField` with no reveal — tokens are pasted, not typed, and
+/// the error-catching job belongs to the live character count.
+struct SecretFormView: View {
+    /// Non-nil = Replace Value… for this name; the name field is locked.
+    let replacingName: String?
+    let existingNames: Set<String>
+    /// `(name, replacedExisting)` on success.
+    let onSaved: (String, Bool) -> Void
+    let onCancel: () -> Void
+    let onImportInstead: () -> Void
+
+    @State private var name: String = ""
+    @State private var value: String = ""
+    @State private var strippedLineBreaks = false
+    @State private var saveFailure: String?
+    @FocusState private var focus: Field?
+    private enum Field { case name, value }
+
+    init(
+        replacingName: String?,
+        existingNames: Set<String>,
+        onSaved: @escaping (String, Bool) -> Void,
+        onCancel: @escaping () -> Void,
+        onImportInstead: @escaping () -> Void
+    ) {
+        self.replacingName = replacingName
+        self.existingNames = existingNames
+        self.onSaved = onSaved
+        self.onCancel = onCancel
+        self.onImportInstead = onImportInstead
+        _name = State(initialValue: replacingName ?? "")
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 14) {
+            nameSection
+            valueSection
+
+            if let saveFailure {
+                Text(saveFailure)
+                    .font(.system(size: 11))
+                    .foregroundColor(.caiError)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+
+            buttons
+
+            if replacingName == nil {
+                Button(action: onImportInstead) {
+                    Text("Import from your shell instead…")
+                        .font(.system(size: 11))
+                        .foregroundColor(.caiTextSecondary)
+                        .underline()
+                }
+                .buttonStyle(.plain)
+            }
+        }
+        .padding(.horizontal, 16)
+        .padding(.vertical, 14)
+        .frame(maxHeight: .infinity, alignment: .top)
+        .onAppear { focus = replacingName == nil ? .name : .value }
+    }
+
+    // MARK: - Name
+
+    private var nameSection: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            Text("Name")
+                .font(.system(size: 11, weight: .medium))
+                .foregroundColor(.caiTextSecondary)
+
+            HStack(spacing: 2) {
+                // The reference syntax teaches itself at naming time — the
+                // destination form's {{ }} grammar.
+                Text("{{secrets.")
+                    .font(.system(size: 11, design: .monospaced))
+                    .foregroundColor(.caiTextSecondary.opacity(0.5))
+                TextField("NOTION_API_TOKEN", text: $name)
+                    .textFieldStyle(.plain)
+                    .font(.system(size: 12, weight: .medium, design: .monospaced))
+                    .focused($focus, equals: .name)
+                    .disabled(replacingName != nil)
+                    .accessibilityLabel("Secret name")
+                Text("}}")
+                    .font(.system(size: 11, design: .monospaced))
+                    .foregroundColor(.caiTextSecondary.opacity(0.5))
+            }
+            .padding(.horizontal, 8)
+            .padding(.vertical, 6)
+            .background(
+                RoundedRectangle(cornerRadius: 8)
+                    .fill(Color(nsColor: .textBackgroundColor))
+            )
+            .overlay(
+                RoundedRectangle(cornerRadius: 8)
+                    .strokeBorder(
+                        focus == .name ? Color.caiPrimary.opacity(0.5) : Color.caiDivider.opacity(0.5),
+                        lineWidth: focus == .name ? 1 : 0.5
+                    )
+            )
+
+            if let problem = nameProblem {
+                Text(problem)
+                    .font(.system(size: 11))
+                    .foregroundColor(.caiError)
+                    .accessibilityLabel(problem)
+            } else if collides {
+                Text("\(name) already exists. Saving replaces its value.")
+                    .font(.system(size: 11))
+                    .foregroundColor(.caiError)
+            }
+        }
+    }
+
+    /// Live validation, only once the user has typed something — an empty
+    /// field is not yet a mistake.
+    private var nameProblem: String? {
+        guard replacingName == nil, !name.isEmpty else { return nil }
+        return SecretReference.nameRejection(name)
+    }
+
+    private var collides: Bool {
+        replacingName == nil && existingNames.contains(name)
+    }
+
+    // MARK: - Value
+
+    private var valueSection: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            Text("Value")
+                .font(.system(size: 11, weight: .medium))
+                .foregroundColor(.caiTextSecondary)
+
+            SecureField("Paste the token", text: $value)
+                .textFieldStyle(.plain)
+                .font(.system(size: 12, design: .monospaced))
+                .focused($focus, equals: .value)
+                .accessibilityLabel("Secret value, hidden")
+                .onChange(of: value) { _, new in
+                    if new.contains(where: \.isNewline) {
+                        value = new.filter { !$0.isNewline }
+                        strippedLineBreaks = true
+                    }
+                }
+                .onSubmit { save() }
+                .padding(.horizontal, 8)
+                .padding(.vertical, 6)
+                .background(
+                    RoundedRectangle(cornerRadius: 8)
+                        .fill(Color(nsColor: .textBackgroundColor))
+                )
+                .overlay(
+                    RoundedRectangle(cornerRadius: 8)
+                        .strokeBorder(
+                            focus == .value ? Color.caiPrimary.opacity(0.5) : Color.caiDivider.opacity(0.5),
+                            lineWidth: focus == .value ? 1 : 0.5
+                        )
+                )
+
+            HStack(spacing: 8) {
+                Text("\(value.count) characters")
+                    .font(.system(size: 11))
+                    .foregroundColor(.caiTextSecondary.opacity(0.7))
+                    .monospacedDigit()
+                    .accessibilityLabel("\(value.count) characters entered")
+                if strippedLineBreaks {
+                    Text("Line breaks removed")
+                        .font(.system(size: 11))
+                        .foregroundColor(.caiTextSecondary.opacity(0.7))
+                }
+            }
+        }
+    }
+
+    // MARK: - Save
+
+    private var canSave: Bool {
+        let effective = replacingName ?? name
+        return SecretReference.isValidName(effective)
+    }
+
+    private var buttons: some View {
+        HStack(spacing: 8) {
+            Spacer()
+            Button("Cancel", action: onCancel)
+                .buttonStyle(.plain)
+                .font(.system(size: 12))
+                .foregroundColor(.caiTextSecondary)
+
+            Button(action: save) {
+                Text(saveLabel)
+                    .font(.system(size: 12, weight: .medium))
+                    .foregroundColor(.white)
+                    .padding(.horizontal, 12)
+                    .padding(.vertical, 5)
+                    .background(
+                        RoundedRectangle(cornerRadius: 6)
+                            .fill(Color.caiPrimary.opacity(canSave ? 1 : 0.4))
+                    )
+            }
+            .buttonStyle(.plain)
+            .disabled(!canSave)
+        }
+    }
+
+    private var saveLabel: String {
+        (replacingName != nil || collides) ? "Replace" : "Save"
+    }
+
+    private func save() {
+        guard canSave else { return }
+        let effective = replacingName ?? name
+        let replaced = replacingName != nil || collides
+
+        switch SecretStore.save(value, name: effective) {
+        case .saved, .replaced:
+            onSaved(effective, replaced)
+        case .invalidName(let why):
+            saveFailure = why
+        case .keychainFailed(let status):
+            saveFailure = "Couldn't save to the Keychain (error \(status))."
+        }
+    }
+}

--- a/Cai/Cai/Views/SecretFormView.swift
+++ b/Cai/Cai/Views/SecretFormView.swift
@@ -161,22 +161,21 @@ struct SecretFormView: View {
                     .monospacedDigit()
                     .accessibilityLabel("\(value.count) characters entered")
                 if valueHasLineBreaks {
-                    // Block, don't silently strip: a stray interior newline (a
-                    // wrapped paste) would corrupt a single-line token, and a
-                    // real multiline secret (a PEM key) belongs in shell import,
-                    // which stores it intact. A trailing newline is trimmed at
-                    // save, so only interior breaks block.
-                    Text("Remove the line breaks — a secret is a single line.")
+                    // Advisory, not a block: interior newlines are legitimate
+                    // (a PEM key, a multiline token) and save keeps them intact.
+                    // Flag it in case the break came from a wrapped paste, but
+                    // let the user decide — orange is Cai's warning color.
+                    Text("Line breaks will be saved as part of the value.")
                         .font(.system(size: 11))
                         .foregroundColor(.caiError)
-                        .accessibilityLabel("Remove the line breaks. A secret is a single line.")
+                        .accessibilityLabel("Warning: line breaks will be saved as part of the value.")
                 }
             }
         }
     }
 
-    /// An interior newline (after trimming the edges save() trims anyway). A
-    /// pasted single-line token with a wrapped break, not a legitimate one.
+    /// An interior newline (after trimming the edges save() trims anyway).
+    /// Drives an advisory warning; the value still saves with the breaks intact.
     private var valueHasLineBreaks: Bool {
         value.trimmingCharacters(in: .whitespacesAndNewlines).contains(where: \.isNewline)
     }
@@ -187,7 +186,6 @@ struct SecretFormView: View {
         let effective = replacingName ?? name
         return SecretReference.isValidName(effective)
             && !value.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
-            && !valueHasLineBreaks
     }
 
     private var buttons: some View {

--- a/Cai/Cai/Views/SecretsManagementView.swift
+++ b/Cai/Cai/Views/SecretsManagementView.swift
@@ -26,6 +26,9 @@ struct SecretsManagementView: View {
     @State private var usageCounts: [String: Int] = [:]
     /// Transient "Saved in Keychain" line (the Connectors grammar).
     @State private var confirmation: String?
+    /// Set when a Keychain delete is refused (locked keychain, denied ACL): the
+    /// row survives `refresh()`, so without this the delete just "doesn't take".
+    @State private var deleteFailure: String?
     @State private var pendingDelete: SecretDescriptor?
 
     /// The router's `handleEsc` consults this before leaving the screen, so
@@ -106,6 +109,9 @@ struct SecretsManagementView: View {
         case .items(let items):
             ScrollView {
                 VStack(spacing: 6) {
+                    if let deleteFailure {
+                        deleteFailureLine(deleteFailure)
+                    }
                     if let confirmation {
                         confirmationLine(confirmation)
                     }
@@ -235,6 +241,23 @@ struct SecretsManagementView: View {
         }
     }
 
+    private func deleteFailureLine(_ text: String) -> some View {
+        HStack(spacing: 6) {
+            Image(systemName: "exclamationmark.triangle.fill")
+                .font(.system(size: 11))
+                .foregroundColor(.caiError)
+            Text(text)
+                .font(.system(size: 11))
+                .foregroundColor(.caiTextPrimary)
+                .fixedSize(horizontal: false, vertical: true)
+            Spacer()
+        }
+        .task {
+            try? await Task.sleep(nanoseconds: 4_000_000_000)
+            withAnimation(.easeOut(duration: 0.2)) { deleteFailure = nil }
+        }
+    }
+
     // MARK: - Delete
 
     private var deleteTitle: String {
@@ -254,10 +277,16 @@ struct SecretsManagementView: View {
     }
 
     private func delete(_ secret: SecretDescriptor) {
-        SecretStore.delete(secret.name)
+        let deleted = SecretStore.delete(secret.name)
         pendingDelete = nil
         refresh()
-        // The row disappearing is the confirmation; no toast.
+        if deleted { ActionsSnapshotPublisher.shared.publishNow() }
+        // The row disappearing is the confirmation; no toast. A refused delete
+        // leaves the row, so say why instead of letting it look like a no-op.
+        if !deleted {
+            confirmation = nil
+            deleteFailure = "\(secret.name) couldn't be deleted from the Keychain."
+        }
     }
 
     // MARK: - Navigation
@@ -278,6 +307,9 @@ struct SecretsManagementView: View {
     private func leaveSubScreen(confirming message: String?) {
         WindowController.passThrough = false  // CAI-22
         refresh()
+        // A save/replace/import may have changed the secret names; republish so
+        // the agent snapshot lists them (a no-op rewrite after a plain cancel).
+        ActionsSnapshotPublisher.shared.publishNow()
         confirmation = message
         withAnimation(.easeInOut(duration: 0.15)) { mode = .list }
     }
@@ -290,6 +322,7 @@ struct SecretsManagementView: View {
     }
 
     private func refresh() {
+        deleteFailure = nil
         listResult = SecretStore.enumerate()
         usageCounts = SecretUsage.counts()
     }

--- a/Cai/Cai/Views/SecretsManagementView.swift
+++ b/Cai/Cai/Views/SecretsManagementView.swift
@@ -1,0 +1,341 @@
+import CaiActionCore
+import SwiftUI
+
+/// Settings → Secrets. A quiet list with a guarded add flow — the design risk
+/// budget went to exactly two places (mono names, the shell import); everything
+/// else is the house pattern. Spec: `_docs/planning/active/SECRETS-UI-DESIGN.md`.
+///
+/// Write-only: a value can be saved, replaced and deleted, and is never
+/// rendered again anywhere in this screen, whatever the state.
+struct SecretsManagementView: View {
+    let onBack: () -> Void
+
+    /// Single-list screen: no tabs, but `ManagementScreen` stays generic.
+    private enum SecretsTab { case main }
+    @State private var tab: SecretsTab = .main
+
+    private enum Mode: Equatable {
+        case list
+        /// `replacing` carries the locked name for Replace Value….
+        case form(replacing: String?)
+        case importing
+    }
+    @State private var mode: Mode = .list
+
+    @State private var listResult: SecretStore.ListResult = .items([])
+    @State private var usageCounts: [String: Int] = [:]
+    /// Transient "Saved in Keychain" line (the Connectors grammar).
+    @State private var confirmation: String?
+    @State private var pendingDelete: SecretDescriptor?
+
+    /// The router's `handleEsc` consults this before leaving the screen, so
+    /// Esc closes an open form first and backs out of the screen second
+    /// (the `MCPFormView.pickerDropdownOpen` precedent).
+    static var escInterceptor: (() -> Bool)?
+
+    var body: some View {
+        ManagementScreen(
+            icon: "key.fill",
+            title: "Secrets",
+            subtitle: "Stored in your Mac's Keychain",
+            tabs: [],
+            selection: $tab,
+            customTabId: nil,
+            onAdd: mode == .list ? { enterForm(replacing: nil) } : nil
+        ) {
+            switch mode {
+            case .list:
+                listContent
+            case .form(let replacing):
+                SecretFormView(
+                    replacingName: replacing,
+                    existingNames: Set(secrets.map(\.name)),
+                    onSaved: { name, replaced in
+                        leaveSubScreen(confirming: replaced ? "\(name) replaced in Keychain" : "Saved in Keychain")
+                    },
+                    onCancel: { leaveSubScreen(confirming: nil) },
+                    onImportInstead: { enterImport() }
+                )
+            case .importing:
+                ShellImportView(
+                    onDone: { saved in
+                        leaveSubScreen(confirming: saved == 0 ? nil : "\(saved) secret\(saved == 1 ? "" : "s") saved in Keychain")
+                    },
+                    onCancel: { leaveSubScreen(confirming: nil) },
+                    onAddManually: { enterForm(replacing: nil) }
+                )
+            }
+        }
+        .onAppear {
+            refresh()
+            Self.escInterceptor = { escPressed() }
+        }
+        .onDisappear {
+            Self.escInterceptor = nil
+            WindowController.passThrough = false
+        }
+        .alert(deleteTitle, isPresented: Binding(
+            get: { pendingDelete != nil },
+            set: { if !$0 { pendingDelete = nil } }
+        )) {
+            Button("Cancel", role: .cancel) { pendingDelete = nil }
+            Button("Delete", role: .destructive) {
+                if let doomed = pendingDelete { delete(doomed) }
+            }
+        } message: {
+            Text(deleteMessage)
+        }
+    }
+
+    // MARK: - List
+
+    private var secrets: [SecretDescriptor] {
+        if case .items(let items) = listResult { return items }
+        return []
+    }
+
+    @ViewBuilder
+    private var listContent: some View {
+        switch listResult {
+        case .unavailable:
+            // Never the empty state: "No secrets yet" over a locked keychain
+            // invites the user to overwrite every secret they own.
+            keychainUnavailableBanner
+        case .items(let items) where items.isEmpty:
+            emptyState
+        case .items(let items):
+            ScrollView {
+                VStack(spacing: 6) {
+                    if let confirmation {
+                        confirmationLine(confirmation)
+                    }
+                    ForEach(items) { secret in
+                        secretRow(secret)
+                    }
+                }
+                .padding(.horizontal, 16)
+                .padding(.vertical, 10)
+            }
+        }
+    }
+
+    private func secretRow(_ secret: SecretDescriptor) -> some View {
+        HStack(spacing: 10) {
+            Image(systemName: "key.fill")
+                .font(.system(size: 14, weight: .medium))
+                .foregroundColor(.caiTextSecondary.opacity(0.5))
+                .frame(width: 20)
+
+            VStack(alignment: .leading, spacing: 2) {
+                // SF Mono: the name is the exact string used in
+                // {{secrets.…}}, and O/0 must be distinguishable (DESIGN.md).
+                Text(secret.name)
+                    .font(.system(size: 12, weight: .medium, design: .monospaced))
+                    .foregroundColor(.caiTextPrimary)
+                    .lineLimit(1)
+                    .truncationMode(.middle)
+                    .help(secret.name)
+                Text(subtitle(for: secret))
+                    .font(.system(size: 11))
+                    .foregroundColor(.caiTextSecondary.opacity(0.7))
+                    .monospacedDigit()
+            }
+
+            Spacer()
+
+            Menu {
+                Button(action: { enterForm(replacing: secret.name) }) {
+                    Label("Replace Value…", systemImage: "arrow.triangle.2.circlepath")
+                }
+                Divider()
+                Button(role: .destructive, action: { pendingDelete = secret }) {
+                    Label("Delete…", systemImage: "trash")
+                }
+            } label: {
+                Image(systemName: "ellipsis")
+                    .font(.system(size: 11, weight: .medium))
+                    .foregroundColor(.caiTextSecondary.opacity(0.6))
+                    .frame(width: 22, height: 22)
+                    .contentShape(Rectangle())
+            }
+            .menuStyle(.borderlessButton)
+            .menuIndicator(.hidden)
+            .fixedSize()
+        }
+        .padding(.horizontal, 12)
+        .padding(.vertical, 10)
+        .background(
+            RoundedRectangle(cornerRadius: 10)
+                .fill(Color.caiSurface.opacity(0.3))
+        )
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel("\(secret.name), \(subtitle(for: secret))")
+    }
+
+    private func subtitle(for secret: SecretDescriptor) -> String {
+        var parts: [String] = []
+        if let created = secret.created {
+            parts.append("Added \(created.formatted(.dateTime.day().month()))")
+        }
+        let uses = usageCounts[secret.name] ?? 0
+        parts.append(uses == 0 ? "Not used yet" : "Used by \(uses) action\(uses == 1 ? "" : "s")")
+        return parts.joined(separator: " · ")
+    }
+
+    private var emptyState: some View {
+        ManagementEmptyState(
+            icon: "key",
+            title: "No secrets yet",
+            description: "A secret stores a token — a Notion key, a GitHub token — once, in your Mac's Keychain. Actions reference it by name and Cai hands it only to the command that runs.",
+            ctaLabel: "Add a Secret",
+            ctaIcon: "plus",
+            ctaAction: { enterForm(replacing: nil) },
+            secondaryCtaLabel: "Import from Shell…",
+            secondaryCtaIcon: "terminal",
+            secondaryCtaAction: { enterImport() }
+        )
+        .frame(maxHeight: .infinity)
+    }
+
+    private var keychainUnavailableBanner: some View {
+        HStack(spacing: 8) {
+            Image(systemName: "exclamationmark.triangle")
+                .font(.system(size: 14, weight: .medium))
+                .foregroundColor(.caiError)
+            Text("Cai can't read the Keychain right now. Unlock it and reopen this screen.")
+                .font(.system(size: 12))
+                .foregroundColor(.caiTextPrimary)
+                .fixedSize(horizontal: false, vertical: true)
+            Spacer()
+        }
+        .padding(.horizontal, 12)
+        .padding(.vertical, 10)
+        .background(
+            RoundedRectangle(cornerRadius: 10)
+                .fill(Color.caiSurface.opacity(0.3))
+        )
+        .padding(.horizontal, 16)
+        .padding(.top, 10)
+        .frame(maxHeight: .infinity, alignment: .top)
+    }
+
+    private func confirmationLine(_ text: String) -> some View {
+        HStack(spacing: 6) {
+            Image(systemName: "checkmark.circle.fill")
+                .font(.system(size: 11))
+                .foregroundColor(.caiSuccess)
+            Text(text)
+                .font(.system(size: 11))
+                .foregroundColor(.caiTextSecondary)
+            Spacer()
+        }
+        .task {
+            try? await Task.sleep(nanoseconds: 2_500_000_000)
+            withAnimation(.easeOut(duration: 0.2)) { confirmation = nil }
+        }
+    }
+
+    // MARK: - Delete
+
+    private var deleteTitle: String {
+        "Delete \(pendingDelete?.name ?? "")?"
+    }
+
+    private var deleteMessage: String {
+        guard let doomed = pendingDelete else { return "" }
+        let affected = SecretUsage.actionNames(referencing: doomed.name)
+        guard !affected.isEmpty else {
+            return "This can't be undone. The value is not recoverable."
+        }
+        let shown = affected.prefix(3).joined(separator: ", ")
+        let more = affected.count > 3 ? " and \(affected.count - 3) more" : ""
+        let verb = affected.count == 1 ? "action references it and will fail" : "actions reference it and will fail"
+        return "\(affected.count) \(verb) until a secret with this name is added again: \(shown)\(more)."
+    }
+
+    private func delete(_ secret: SecretDescriptor) {
+        SecretStore.delete(secret.name)
+        pendingDelete = nil
+        refresh()
+        // The row disappearing is the confirmation; no toast.
+    }
+
+    // MARK: - Navigation
+
+    private func enterForm(replacing: String?) {
+        confirmation = nil
+        WindowController.passThrough = true  // CAI-22
+        withAnimation(.easeInOut(duration: 0.15)) { mode = .form(replacing: replacing) }
+    }
+
+    private func enterImport() {
+        confirmation = nil
+        WindowController.passThrough = true  // CAI-22: the candidate list has no
+        // text field, but the flow can bounce into the form via "Add manually".
+        withAnimation(.easeInOut(duration: 0.15)) { mode = .importing }
+    }
+
+    private func leaveSubScreen(confirming message: String?) {
+        WindowController.passThrough = false  // CAI-22
+        refresh()
+        confirmation = message
+        withAnimation(.easeInOut(duration: 0.15)) { mode = .list }
+    }
+
+    /// True when Esc was consumed internally (a sub-screen was open).
+    private func escPressed() -> Bool {
+        guard mode != .list else { return false }
+        leaveSubScreen(confirming: nil)
+        return true
+    }
+
+    private func refresh() {
+        listResult = SecretStore.enumerate()
+        usageCounts = SecretUsage.counts()
+    }
+}
+
+// MARK: - Usage scanning
+
+/// Where each secret is referenced, per the advisory scanner. Powers the row
+/// subtitles ("Used by 2 actions") and the delete confirmation's list of
+/// what breaks. Advisory means over-reporting is acceptable; execution never
+/// consults this.
+enum SecretUsage {
+
+    /// Reference counts by secret name across shortcuts and destinations.
+    static func counts() -> [String: Int] {
+        var counts: [String: Int] = [:]
+        for template in templates() {
+            for name in SecretReference.names(in: template.text) {
+                counts[name, default: 0] += 1
+            }
+        }
+        return counts
+    }
+
+    /// Names of the actions/destinations whose templates reference `name`.
+    static func actionNames(referencing name: String) -> [String] {
+        templates()
+            .filter { SecretReference.names(in: $0.text).contains(name) }
+            .map(\.owner)
+    }
+
+    private static func templates() -> [(owner: String, text: String)] {
+        var found: [(String, String)] = []
+        for shortcut in CaiSettings.shared.shortcuts {
+            found.append((shortcut.name, shortcut.value))
+        }
+        // Destinations keep their templates in kind-specific config; encoding
+        // the whole definition and scanning that is what keeps this correct
+        // when a new template-bearing field is added.
+        let encoder = JSONEncoder()
+        for destination in CaiSettings.shared.outputDestinations {
+            if let data = try? encoder.encode(destination),
+               let json = String(data: data, encoding: .utf8) {
+                found.append((destination.name, json))
+            }
+        }
+        return found
+    }
+}

--- a/Cai/Cai/Views/SecretsManagementView.swift
+++ b/Cai/Cai/Views/SecretsManagementView.swift
@@ -192,7 +192,7 @@ struct SecretsManagementView: View {
         ManagementEmptyState(
             icon: "key",
             title: "No secrets yet",
-            description: "A secret stores a token — a Notion key, a GitHub token — once, in your Mac's Keychain. Actions reference it by name and Cai hands it only to the command that runs.",
+            description: "Actions reference it by name and Cai hands it only to the command that runs.",
             ctaLabel: "Add a Secret",
             ctaIcon: "plus",
             ctaAction: { enterForm(replacing: nil) },
@@ -271,9 +271,9 @@ struct SecretsManagementView: View {
             return "This can't be undone. The value is not recoverable."
         }
         let shown = affected.prefix(3).joined(separator: ", ")
-        let more = affected.count > 3 ? " and \(affected.count - 3) more" : ""
-        let verb = affected.count == 1 ? "action references it and will fail" : "actions reference it and will fail"
-        return "\(affected.count) \(verb) until a secret with this name is added again: \(shown)\(more)."
+        let more = affected.count > 3 ? " +\(affected.count - 3) more" : ""
+        let noun = affected.count == 1 ? "action uses" : "actions use"
+        return "\(affected.count) \(noun) it and will fail until you re-add it: \(shown)\(more)."
     }
 
     private func delete(_ secret: SecretDescriptor) {

--- a/Cai/Cai/Views/SettingsView.swift
+++ b/Cai/Cai/Views/SettingsView.swift
@@ -10,6 +10,7 @@ struct SettingsView: View {
     var onShowDestinations: (() -> Void)? = nil
     var onShowExtensions: (() -> Void)? = nil
     var onShowConnectors: (() -> Void)? = nil
+    var onShowSecrets: (() -> Void)? = nil
     var onShowBuiltInActions: (() -> Void)? = nil
     var onShowModelSetup: (() -> Void)? = nil
     var onDismiss: (() -> Void)? = nil
@@ -291,6 +292,14 @@ struct SettingsView: View {
                         settingsDivider
 
                         mcpNavRow
+
+                        settingsDivider
+
+                        // Own top-level row (SECRETS-MLP-PLAN locked decision 7):
+                        // shell actions, chains and destinations all consume
+                        // secrets, so filing it under any one would hide it
+                        // from the others.
+                        navRow(label: "Secrets", count: SecretStore.list().count, action: onShowSecrets)
                     }
 
                     Button(action: onShowExtensions ?? {}) {

--- a/Cai/Cai/Views/SettingsView.swift
+++ b/Cai/Cai/Views/SettingsView.swift
@@ -22,6 +22,9 @@ struct SettingsView: View {
     @State private var llmStatusError: String? = nil
     /// Available models from the current provider
     @State private var availableModels: [String] = []
+    /// Secret count for the nav row, read once when settings opens instead of
+    /// enumerating the Keychain (`SecItemCopyMatching`) on every body redraw.
+    @State private var secretCount: Int = 0
     /// Debounce task for LLM status checks (prevents API call storms during typing)
     @State private var statusCheckTask: Task<Void, Never>?
     /// Debounce task for model list fetches (prevents API call storms during key paste/typing)
@@ -299,7 +302,7 @@ struct SettingsView: View {
                         // shell actions, chains and destinations all consume
                         // secrets, so filing it under any one would hide it
                         // from the others.
-                        navRow(label: "Secrets", count: SecretStore.list().count, action: onShowSecrets)
+                        navRow(label: "Secrets", count: secretCount, action: onShowSecrets)
                     }
 
                     Button(action: onShowExtensions ?? {}) {
@@ -590,6 +593,7 @@ struct SettingsView: View {
             permissions.checkAccessibilityPermission()
             checkLLMStatus()
             fetchAvailableModels()
+            secretCount = SecretStore.list().count
         }
     }
 

--- a/Cai/Cai/Views/ShellImportView.swift
+++ b/Cai/Cai/Views/ShellImportView.swift
@@ -182,6 +182,11 @@ struct ShellImportView: View {
                 failures.append((candidate.name, status))
             }
         }
+        // Republish here, not only on the way out: a partial failure parks on
+        // the .partial screen without calling onDone, and if the user abandons
+        // it (focus loss, quit) the secrets that DID save would otherwise stay
+        // invisible to the agent until the next relaunch.
+        if saved > 0 { ActionsSnapshotPublisher.shared.publishNow() }
         if failures.isEmpty {
             onDone(saved)
         } else {

--- a/Cai/Cai/Views/ShellImportView.swift
+++ b/Cai/Cai/Views/ShellImportView.swift
@@ -1,0 +1,272 @@
+import CaiActionCore
+import SwiftUI
+
+/// Import from shell — three states inline in the list area: working,
+/// candidates, failure. Values are never rendered in any state, not even
+/// masked; the checkbox rows show names only.
+struct ShellImportView: View {
+    /// Called with how many secrets were saved (0 = nothing imported).
+    let onDone: (Int) -> Void
+    let onCancel: () -> Void
+    let onAddManually: () -> Void
+
+    private enum Phase {
+        case working
+        case candidates([ShellEnvCapture.Candidate])
+        case failed(String)
+        /// Some saves failed: names that made it, names that did not.
+        case partial(saved: Int, failures: [(name: String, status: OSStatus)])
+    }
+    @State private var phase: Phase = .working
+    @State private var ticked: Set<String> = []
+    @State private var showAll = false
+    @State private var pulsing = false
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            privacyLine
+
+            switch phase {
+            case .working:
+                working
+            case .candidates(let candidates):
+                if candidates.isEmpty {
+                    emptyCapture
+                } else {
+                    candidateList(candidates)
+                    footer(candidates)
+                }
+            case .failed(let why):
+                failure(why)
+            case .partial(let saved, let failures):
+                partial(saved: saved, failures: failures)
+            }
+        }
+        .padding(.horizontal, 16)
+        .padding(.vertical, 12)
+        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+        .task { await capture() }
+    }
+
+    private var privacyLine: some View {
+        Text("Cai runs your login shell once to read its environment. Values go straight to the Keychain and are never shown.")
+            .font(.system(size: 11))
+            .foregroundColor(.caiTextSecondary.opacity(0.7))
+            .fixedSize(horizontal: false, vertical: true)
+    }
+
+    // MARK: - Working
+
+    private var working: some View {
+        HStack(spacing: 8) {
+            Text("◉")
+                .font(.system(size: 12))
+                .foregroundColor(.caiTextSecondary)
+                .opacity(pulsing ? 1.0 : 0.45)
+                .animation(.easeInOut(duration: 1.2).repeatForever(autoreverses: true), value: pulsing)
+                .onAppear { pulsing = true }
+                .accessibilityAddTraits(.updatesFrequently)
+            Text("Reading your shell environment…")
+                .font(.system(size: 12))
+                .foregroundColor(.caiTextSecondary)
+        }
+        .padding(.top, 8)
+    }
+
+    private func capture() async {
+        do {
+            let found = try await ShellEnvCapture.capture()
+            // Preselect nothing: importing a credential is an explicit act.
+            withAnimation(.easeOut(duration: 0.2)) { phase = .candidates(found) }
+        } catch {
+            withAnimation(.easeOut(duration: 0.2)) {
+                phase = .failed(error.localizedDescription)
+            }
+        }
+    }
+
+    // MARK: - Candidates
+
+    @ViewBuilder
+    private func candidateList(_ candidates: [ShellEnvCapture.Candidate]) -> some View {
+        let tokenish = candidates.filter(\.looksLikeToken)
+        let rest = candidates.filter { !$0.looksLikeToken }
+
+        ScrollView {
+            VStack(alignment: .leading, spacing: 2) {
+                ForEach(tokenish, id: \.name) { candidateRow($0) }
+
+                if !rest.isEmpty {
+                    if showAll {
+                        ForEach(rest, id: \.name) { candidateRow($0) }
+                    } else {
+                        Button(action: { withAnimation(.easeOut(duration: 0.15)) { showAll = true } }) {
+                            Text("Show all (\(rest.count))")
+                                .font(.system(size: 11))
+                                .foregroundColor(.caiTextSecondary)
+                                .underline()
+                        }
+                        .buttonStyle(.plain)
+                        .padding(.top, 4)
+                    }
+                }
+            }
+        }
+        .frame(maxHeight: 240)
+    }
+
+    private func candidateRow(_ candidate: ShellEnvCapture.Candidate) -> some View {
+        HStack(spacing: 8) {
+            Toggle(isOn: Binding(
+                get: { ticked.contains(candidate.name) },
+                set: { on in
+                    if on { ticked.insert(candidate.name) } else { ticked.remove(candidate.name) }
+                }
+            )) {
+                Text(candidate.name)
+                    .font(.system(size: 12, weight: .medium, design: .monospaced))
+                    .foregroundColor(.caiTextPrimary)
+                    .lineLimit(1)
+                    .truncationMode(.middle)
+                    .help(candidate.name)
+            }
+            .toggleStyle(.checkbox)
+
+            if candidate.replacesExisting {
+                Text("replaces existing")
+                    .font(.system(size: 11))
+                    .foregroundColor(.caiError)
+            }
+            Spacer()
+        }
+        .padding(.vertical, 2)
+    }
+
+    private func footer(_ candidates: [ShellEnvCapture.Candidate]) -> some View {
+        HStack(spacing: 8) {
+            Spacer()
+            Button("Cancel", action: onCancel)
+                .buttonStyle(.plain)
+                .font(.system(size: 12))
+                .foregroundColor(.caiTextSecondary)
+
+            Button(action: { importTicked(from: candidates) }) {
+                Text("Import \(ticked.count) Secret\(ticked.count == 1 ? "" : "s")")
+                    .font(.system(size: 12, weight: .medium))
+                    .foregroundColor(.white)
+                    .monospacedDigit()
+                    .padding(.horizontal, 12)
+                    .padding(.vertical, 5)
+                    .background(
+                        RoundedRectangle(cornerRadius: 6)
+                            .fill(Color.caiPrimary.opacity(ticked.isEmpty ? 0.4 : 1))
+                    )
+            }
+            .buttonStyle(.plain)
+            .disabled(ticked.isEmpty)
+        }
+    }
+
+    private func importTicked(from candidates: [ShellEnvCapture.Candidate]) {
+        var saved = 0
+        var failures: [(String, OSStatus)] = []
+        for candidate in candidates where ticked.contains(candidate.name) {
+            switch SecretStore.save(candidate.value.raw, name: candidate.name) {
+            case .saved, .replaced:
+                saved += 1
+            case .invalidName:
+                // Cannot happen: candidates passed isValidName. Counted as a
+                // failure rather than dropped silently, just in case.
+                failures.append((candidate.name, errSecParam))
+            case .keychainFailed(let status):
+                failures.append((candidate.name, status))
+            }
+        }
+        if failures.isEmpty {
+            onDone(saved)
+        } else {
+            withAnimation(.easeOut(duration: 0.2)) {
+                phase = .partial(saved: saved, failures: failures)
+            }
+        }
+    }
+
+    // MARK: - Empty / failure / partial
+
+    private var emptyCapture: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            Text("No token-shaped variables found in your shell.")
+                .font(.system(size: 12))
+                .foregroundColor(.caiTextPrimary)
+            addManuallyButton
+        }
+        .padding(.top, 8)
+    }
+
+    private func failure(_ why: String) -> some View {
+        VStack(alignment: .leading, spacing: 10) {
+            HStack(spacing: 6) {
+                Image(systemName: "exclamationmark.triangle")
+                    .font(.system(size: 12, weight: .medium))
+                    .foregroundColor(.caiError)
+                Text("Couldn't read your shell environment.")
+                    .font(.system(size: 12))
+                    .foregroundColor(.caiTextPrimary)
+            }
+            Text(why)
+                .font(.system(size: 11))
+                .foregroundColor(.caiTextSecondary.opacity(0.7))
+                .fixedSize(horizontal: false, vertical: true)
+            addManuallyButton
+        }
+        .padding(.top, 8)
+    }
+
+    private func partial(saved: Int, failures: [(name: String, status: OSStatus)]) -> some View {
+        VStack(alignment: .leading, spacing: 10) {
+            if saved > 0 {
+                HStack(spacing: 6) {
+                    Image(systemName: "checkmark.circle.fill")
+                        .font(.system(size: 11))
+                        .foregroundColor(.caiSuccess)
+                    Text("\(saved) secret\(saved == 1 ? "" : "s") saved in Keychain")
+                        .font(.system(size: 12))
+                        .foregroundColor(.caiTextPrimary)
+                        .monospacedDigit()
+                }
+            }
+            ForEach(failures, id: \.name) { failure in
+                Text("\(failure.name) couldn't be saved (Keychain error \(failure.status)).")
+                    .font(.system(size: 11, design: .monospaced))
+                    .foregroundColor(.caiError)
+            }
+            HStack(spacing: 8) {
+                Spacer()
+                Button("Done") { onDone(saved) }
+                    .buttonStyle(.plain)
+                    .font(.system(size: 12))
+                    .foregroundColor(.caiTextSecondary)
+            }
+        }
+        .padding(.top, 8)
+    }
+
+    private var addManuallyButton: some View {
+        Button(action: onAddManually) {
+            Text("Add manually instead")
+                .font(.system(size: 11, weight: .medium))
+                .foregroundColor(.caiTextSecondary)
+                .padding(.horizontal, 10)
+                .padding(.vertical, 5)
+                .background(
+                    RoundedRectangle(cornerRadius: 5)
+                        .fill(Color.caiSurface.opacity(0.6))
+                )
+                .overlay(
+                    RoundedRectangle(cornerRadius: 5)
+                        .strokeBorder(Color.caiDivider.opacity(0.5), lineWidth: 0.5)
+                )
+        }
+        .buttonStyle(.plain)
+    }
+}

--- a/Cai/CaiActionCore/Sources/CaiActionCore/ActionsSnapshot.swift
+++ b/Cai/CaiActionCore/Sources/CaiActionCore/ActionsSnapshot.swift
@@ -12,6 +12,12 @@ import Foundation
 /// and headers can carry credentials, and nothing about authoring needs them.
 /// Names and kinds are enough to resolve a chain step and to tell the user
 /// what an action will reach.
+///
+/// Secret *names* are present (`secretNames`) so an agent references the one
+/// the user actually stored instead of guessing (`NOTION_TOKEN` for a secret
+/// named `NOTION_API`). Values are never here — the same names already surface
+/// through any existing action's template, and the value is unreadable to the
+/// helper regardless.
 public struct ActionsSnapshot: Codable, Equatable, Sendable {
 
     public let schemaVersion: Int
@@ -20,6 +26,9 @@ public struct ActionsSnapshot: Codable, Equatable, Sendable {
     public let destinations: [DestinationSummary]
     /// Display labels of chainable built-in actions.
     public let builtInActionNames: [String]
+    /// Names of the secrets stored on this Mac, sorted. Names only, never
+    /// values — so an agent can write the right `{{secrets.NAME}}` reference.
+    public let secretNames: [String]
     /// The kill switch. When false the helper refuses to write anything, so an
     /// agent gets a clear error instead of proposals that queue into a
     /// directory the app has stopped watching.
@@ -31,6 +40,7 @@ public struct ActionsSnapshot: Codable, Equatable, Sendable {
         actions: [ActionSnapshot],
         destinations: [DestinationSummary],
         builtInActionNames: [String],
+        secretNames: [String] = [],
         agentAuthoringEnabled: Bool
     ) {
         self.schemaVersion = schemaVersion
@@ -38,7 +48,29 @@ public struct ActionsSnapshot: Codable, Equatable, Sendable {
         self.actions = actions
         self.destinations = destinations
         self.builtInActionNames = builtInActionNames
+        self.secretNames = secretNames
         self.agentAuthoringEnabled = agentAuthoringEnabled
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case schemaVersion, generatedAt, actions, destinations
+        case builtInActionNames, secretNames, agentAuthoringEnabled
+    }
+
+    /// Hand-rolled only so `secretNames` decodes as `[]` when absent. A snapshot
+    /// written before this field existed still sits on disk right after an app
+    /// update, until the new app relaunches and republishes; a synthesized
+    /// decoder would throw `keyNotFound` on it and blank `list_actions` in the
+    /// meantime. Everything else decodes exactly as the synthesis would.
+    public init(from decoder: Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        schemaVersion = try c.decode(Int.self, forKey: .schemaVersion)
+        generatedAt = try c.decode(Date.self, forKey: .generatedAt)
+        actions = try c.decode([ActionSnapshot].self, forKey: .actions)
+        destinations = try c.decode([DestinationSummary].self, forKey: .destinations)
+        builtInActionNames = try c.decode([String].self, forKey: .builtInActionNames)
+        secretNames = try c.decodeIfPresent([String].self, forKey: .secretNames) ?? []
+        agentAuthoringEnabled = try c.decode(Bool.self, forKey: .agentAuthoringEnabled)
     }
 
     /// The same view of the world the app validates against, so the helper's

--- a/Cai/CaiActionCore/Sources/CaiActionCore/AgentReply.swift
+++ b/Cai/CaiActionCore/Sources/CaiActionCore/AgentReply.swift
@@ -39,6 +39,17 @@ public enum AgentReply {
             lines.append("Built-in actions a chain step can name: "
                 + snapshot.builtInActionNames.joined(separator: ", "))
         }
+        // Gated on the kill switch: an agent that can't propose has no use for
+        // the names, so it doesn't get them. The publisher already withholds
+        // them from the file when off; this is the second layer, so a snapshot
+        // built with names + authoring-off still can't leak them here.
+        if snapshot.agentAuthoringEnabled, !snapshot.secretNames.isEmpty {
+            lines.append("")
+            lines.append("Stored secrets, referenced as {{secrets.NAME}} in a shell command "
+                + "(use one of these exact names, never invent one; keep the reference in "
+                + "double quotes, never single quotes; you never see the value): "
+                + snapshot.secretNames.joined(separator: ", "))
+        }
 
         lines.append("")
         if statuses.isEmpty {

--- a/Cai/CaiActionCore/Sources/CaiActionCore/ApprovalTier.swift
+++ b/Cai/CaiActionCore/Sources/CaiActionCore/ApprovalTier.swift
@@ -29,6 +29,12 @@ public enum EscalationReason: String, Codable, Equatable, Sendable, CaseIterable
     /// risk is the blind handoff, so it escalates now, while the user is
     /// looking.
     case chainsToUnknownAction
+    /// A template reaches for a `{{secrets.NAME}}` reference. No associated
+    /// names: this enum is `String`-raw `Codable` and persisted with
+    /// proposals, so the sheet re-scans the templates at render time for the
+    /// names — which also means the callout can never show names computed
+    /// from a stale validation (CAI-25).
+    case referencesSecrets
 }
 
 public enum ApprovalClassifier {
@@ -82,6 +88,12 @@ public enum ApprovalClassifier {
             if current.type == .url { found.insert(.sendsSelectionToURL) }
             if current.autoReplaceSelection { found.insert(.replacesSelection) }
             if current.runInBackground { found.insert(.runsWithoutShowingOutput) }
+            // The advisory scanner, not the engine's parser: over-reporting
+            // here makes a proposal look slightly scarier, never less scary,
+            // and execution resolves names through the engine regardless.
+            if SecretReference.referencesAnySecret(current.value) {
+                found.insert(.referencesSecrets)
+            }
 
             guard depth < ActionSchema.maxChainSteps else { continue }
 

--- a/Cai/CaiMCPHelper/Tools.swift
+++ b/Cai/CaiMCPHelper/Tools.swift
@@ -79,8 +79,11 @@ enum Tools {
             example https://www.google.com/search?q=%s. Other schemes are refused; the user can \
             create those by hand in Cai.
             - shell: runs a shell command. Use {{result}} where the selection should go; Cai \
-            escapes it for you, so do not add quotes around it. Shell actions always require an \
-            extra confirmation from the user, so keep them to one obvious job.
+            escapes it for you, so do not add quotes around it. To use a stored credential, \
+            write {{secrets.NAME}} and keep it inside double quotes, never single quotes; \
+            list_actions shows which secret names exist, so use one of those exact names and \
+            never paste a real token into the command. Shell actions always require an extra \
+            confirmation from the user, so keep them to one obvious job.
 
             Flags: autoReplaceSelection pastes the model's answer straight over the user's \
             selection (prompt actions only). runInBackground skips showing output (shell actions \

--- a/Cai/CaiTests/ActionReviewPresentationTests.swift
+++ b/Cai/CaiTests/ActionReviewPresentationTests.swift
@@ -45,6 +45,46 @@ final class ActionReviewPresentationTests: XCTestCase {
         )
     }
 
+    // MARK: - Secrets callout (SECRETS-UI-DESIGN.md surface 5)
+
+    func testTheSecretsCalloutNamesWhatThePayloadReachesFor() {
+        XCTAssertEqual(
+            ActionReviewPresentation.callout(for: .referencesSecrets, secretNames: ["NOTION_API_TOKEN"]),
+            "This action uses your secret NOTION_API_TOKEN."
+        )
+        XCTAssertEqual(
+            ActionReviewPresentation.callout(for: .referencesSecrets, secretNames: ["B_TOKEN", "A_TOKEN"]),
+            "This action uses your secrets A_TOKEN and B_TOKEN."
+        )
+    }
+
+    func testTheSecretsCalloutWithoutNamesStillWarns() {
+        // A chained action can carry the reason while the proposal's own text
+        // has no reference; generic beats silent.
+        XCTAssertEqual(
+            ActionReviewPresentation.callout(for: .referencesSecrets),
+            "This action uses one of your secrets."
+        )
+        XCTAssertEqual(
+            ActionReviewPresentation.calloutBullet(for: .referencesSecrets),
+            "Use one of your secrets"
+        )
+    }
+
+    func testSecretListFormatting() {
+        XCTAssertEqual(ActionReviewPresentation.secretList(["A"]), "A")
+        XCTAssertEqual(ActionReviewPresentation.secretList(["B", "A"]), "A and B")
+        XCTAssertEqual(ActionReviewPresentation.secretList(["C", "A", "B"]), "A, B and C")
+    }
+
+    func testSecretNamesOnlyChangeTheSecretsCallout() {
+        // Passing names must not perturb the other reasons' verbatim copy.
+        XCTAssertEqual(
+            ActionReviewPresentation.callout(for: .runsShellCommands, secretNames: ["NOTION_API_TOKEN"]),
+            "This action can run terminal commands on your Mac."
+        )
+    }
+
     // MARK: - Grouped callout
 
     func testOneRiskKeepsTheSpecsSentence() {
@@ -92,7 +132,7 @@ final class ActionReviewPresentationTests: XCTestCase {
             ActionReviewPresentation.approvedToast(isUpdate: false),
             ActionReviewPresentation.approvedToast(isUpdate: true),
         ]
-        strings += EscalationReason.allCases.map(ActionReviewPresentation.callout)
+        strings += EscalationReason.allCases.map { ActionReviewPresentation.callout(for: $0) }
         strings.append(ActionReviewPresentation.acknowledgmentLabel)
         strings += ActionField.allCases.map(ActionReviewPresentation.fieldLabel)
 

--- a/Cai/CaiTests/AgentReplyTests.swift
+++ b/Cai/CaiTests/AgentReplyTests.swift
@@ -10,6 +10,7 @@ final class AgentReplyTests: XCTestCase {
 
     private func snapshot(
         actions: [ActionSnapshot] = [CoreFixture.snapshot()],
+        secretNames: [String] = [],
         enabled: Bool = true
     ) -> ActionsSnapshot {
         ActionsSnapshot(
@@ -17,6 +18,7 @@ final class AgentReplyTests: XCTestCase {
             actions: actions,
             destinations: [DestinationSummary(name: "Slack", kind: .webhook)],
             builtInActionNames: ["Summarize"],
+            secretNames: secretNames,
             agentAuthoringEnabled: enabled
         )
     }
@@ -37,6 +39,43 @@ final class AgentReplyTests: XCTestCase {
 
         XCTAssertTrue(text.contains("Destinations a chain step can name: Slack"))
         XCTAssertTrue(text.contains("Built-in actions a chain step can name: Summarize"))
+    }
+
+    func testListingNamesStoredSecretsSoTheAgentDoesNotGuess() {
+        let text = AgentReply.actionsListing(
+            snapshot: snapshot(secretNames: ["NOTION_API", "GITHUB_TOKEN"]),
+            statuses: []
+        )
+        // The exact names the agent must reference, plus the two rules that
+        // trip execution otherwise: {{secrets.NAME}} syntax and double quotes.
+        XCTAssertTrue(text.contains("NOTION_API"), text)
+        XCTAssertTrue(text.contains("GITHUB_TOKEN"), text)
+        XCTAssertTrue(text.contains("{{secrets.NAME}}"), text)
+        XCTAssertTrue(text.contains("double quotes"), text)
+    }
+
+    func testListingOmitsTheSecretsSectionWhenThereAreNone() {
+        let text = AgentReply.actionsListing(snapshot: snapshot(), statuses: [])
+        XCTAssertFalse(text.contains("Stored secrets"), text)
+    }
+
+    func testSecretNamesAreWithheldWhenAuthoringIsOff() {
+        // The kill switch gates name exposure: an agent that cannot propose has
+        // no use for the names, so even a snapshot that carries them must not
+        // surface them.
+        let text = AgentReply.actionsListing(
+            snapshot: snapshot(secretNames: ["NOTION_API"], enabled: false),
+            statuses: []
+        )
+        XCTAssertFalse(text.contains("Stored secrets"), text)
+        XCTAssertFalse(text.contains("NOTION_API"), text)
+    }
+
+    func testStoredSecretNamesAreNamesOnlyNeverValues() {
+        // The snapshot carries names; there is no value field to leak. Guard the
+        // invariant so a future field addition can't quietly ship values.
+        let snap = snapshot(secretNames: ["NOTION_API"])
+        XCTAssertEqual(snap.secretNames, ["NOTION_API"])
     }
 
     func testListingShowsAChainSoItIsNotProposedTwice() {

--- a/Cai/CaiTests/CaiActionCoreApprovalTierTests.swift
+++ b/Cai/CaiTests/CaiActionCoreApprovalTierTests.swift
@@ -49,6 +49,27 @@ final class ApprovalTierTests: XCTestCase {
                 line: #line
             ),
             TierCase(
+                label: "shell reaching for a secret",
+                action: CoreFixture.snapshot(
+                    type: .shell,
+                    value: "curl -H \"Bearer {{secrets.NOTION_API_TOKEN}}\" https://api.notion.com"
+                ),
+                expected: [.runsShellCommands, .referencesSecrets],
+                line: #line
+            ),
+            TierCase(
+                label: "prompt mentioning a secret still flags it (refused at execution, but the approval must not undersell)",
+                action: CoreFixture.snapshot(type: .prompt, value: "Use {{secrets.NOTION_API_TOKEN}}"),
+                expected: [.referencesSecrets],
+                line: #line
+            ),
+            TierCase(
+                label: "bare uppercase placeholder is an ordinary variable, not a secret",
+                action: CoreFixture.snapshot(type: .shell, value: "echo {{API_KEY}}"),
+                expected: [.runsShellCommands],
+                line: #line
+            ),
+            TierCase(
                 label: "prompt chaining into a shell destination",
                 action: CoreFixture.snapshot(next: [.action(name: "Run script")]),
                 expected: [.runsShellCommands],
@@ -142,6 +163,26 @@ final class ApprovalTierTests: XCTestCase {
     }
 
     // MARK: - Chains that reference other actions
+
+    func testAChainedActionsSecretReferenceEscalatesTheProposal() {
+        // The proposal's own text is innocent; the installed action it chains
+        // into reaches for a token. The union must carry both reasons — the
+        // callout falls back to generic copy when the payload on screen has
+        // no reference of its own.
+        let installed = CoreFixture.snapshot(
+            id: UUID(),
+            name: "Post to Notion",
+            type: .shell,
+            value: "curl -H \"Bearer {{secrets.NOTION_API_TOKEN}}\" https://api.notion.com"
+        )
+        let known = KnownActions(shortcuts: [installed], destinations: [], builtInActionNames: [])
+        let proposal = CoreFixture.snapshot(id: UUID(), type: .prompt, next: [.action(name: "Post to Notion")])
+
+        XCTAssertEqual(
+            ApprovalClassifier.escalationReasons(for: proposal, known: known),
+            [.runsShellCommands, .referencesSecrets]
+        )
+    }
 
     func testEscalationFollowsAReferencedShortcutsOwnType() {
         let shellAction = CoreFixture.snapshot(id: CoreFixture.otherId, name: "Deploy", type: .shell, value: "./deploy.sh")

--- a/Cai/CaiTests/HelperHandoffTests.swift
+++ b/Cai/CaiTests/HelperHandoffTests.swift
@@ -38,6 +38,29 @@ final class HelperHandoffTests: XCTestCase {
         )
     }
 
+    func testASnapshotWrittenBeforeSecretNamesStillDecodes() throws {
+        // A file the previous app version wrote — no `secretNames` key. It sits
+        // on disk after an update until the app relaunches; the helper must read
+        // it rather than throw and blank list_actions. `secretNames` defaults to
+        // empty, everything else decodes as before.
+        let legacy = """
+        {
+          "schemaVersion": \(ActionSchema.version),
+          "generatedAt": "2001-01-01T00:00:00Z",
+          "actions": [],
+          "destinations": [],
+          "builtInActionNames": ["Summarize"],
+          "agentAuthoringEnabled": true
+        }
+        """
+        let snapshot = try ActionCoding.decoder.decode(
+            ActionsSnapshot.self, from: Data(legacy.utf8)
+        )
+        XCTAssertEqual(snapshot.secretNames, [])
+        XCTAssertEqual(snapshot.builtInActionNames, ["Summarize"])
+        XCTAssertTrue(snapshot.agentAuthoringEnabled)
+    }
+
     func testSnapshotIsOwnerOnly() throws {
         ActionsSnapshotPublisher(root: root).publishNow()
 

--- a/Cai/CaiTests/SecretStoreTests.swift
+++ b/Cai/CaiTests/SecretStoreTests.swift
@@ -61,11 +61,19 @@ final class SecretStoreTests: XCTestCase {
         XCTAssertNil(SecretStore.value(for: "bad name"))
     }
 
-    func testAnEmptyValueIsStorable() {
-        // Not our business to police the token format, and refusing would be a
-        // confusing failure at save time.
-        XCTAssertEqual(SecretStore.save("", name: testName), .saved)
-        XCTAssertEqual(SecretStore.value(for: testName)?.raw, "")
+    func testAnEmptyValueIsRefused() {
+        // An empty value stores fine at the Keychain layer but hands a blank
+        // credential to the command at run time, failing far away with the
+        // wrong error. Refuse it at the source — both the form and a `FOO=`
+        // shell-import entry stop here rather than persisting a blank secret.
+        guard case .invalidName = SecretStore.save("", name: testName) else {
+            return XCTFail("empty value should be refused")
+        }
+        // Whitespace-only collapses to empty after the trim and is refused too.
+        guard case .invalidName = SecretStore.save("   \n", name: testName) else {
+            return XCTFail("whitespace-only value should be refused")
+        }
+        XCTAssertFalse(SecretStore.exists(testName), "nothing was persisted")
     }
 
     func testAPastedTrailingNewlineIsTrimmedAtSave() {

--- a/Cai/CaiTests/SecretStoreTests.swift
+++ b/Cai/CaiTests/SecretStoreTests.swift
@@ -135,6 +135,18 @@ final class SecretStoreTests: XCTestCase {
         XCTAssertTrue(SecretStore.exists(testName))
     }
 
+    func testEnumerateReportsItemsAndListMatches() {
+        // The unavailable branch can't be forced against a live keychain; what
+        // can be pinned is that the healthy path reports .items and that the
+        // convenience list() is exactly those items.
+        SecretStore.save("v", name: testName)
+        guard case .items(let items) = SecretStore.enumerate() else {
+            return XCTFail("a healthy keychain reported unavailable")
+        }
+        XCTAssertEqual(items, SecretStore.list())
+        XCTAssertTrue(items.contains { $0.name == testName })
+    }
+
     // MARK: - Resolution for a shell command
 
     func testATemplateWithoutSecretsChangesNothing() throws {

--- a/Cai/CaiTests/ShellEnvCaptureTests.swift
+++ b/Cai/CaiTests/ShellEnvCaptureTests.swift
@@ -1,0 +1,106 @@
+import XCTest
+import CaiActionCore
+@testable import Cai
+
+/// The import-from-shell capture: parse and filter as pure tables, plus one
+/// real login-shell integration run (the `SecretEndToEndTests` precedent:
+/// nothing short of a real shell proves the marker survives rc noise).
+final class ShellEnvCaptureTests: XCTestCase {
+
+    private let marker = ShellEnvCapture.marker
+
+    private func names(_ output: String, existing: Set<String> = []) -> [String] {
+        ShellEnvCapture.candidates(fromCaptureOutput: output, existing: existing).map(\.name)
+    }
+
+    // MARK: - Parsing
+
+    func testParsingTable() {
+        let cases: [(String, [String], String)] = [
+            ("", [], "empty output"),
+            ("GITHUB_TOKEN=x\u{0}", [], "no marker means no trusted region"),
+            (marker + "GITHUB_TOKEN=abc\u{0}", ["GITHUB_TOKEN"], "one entry"),
+            (
+                "motd noise\nFAKE_TOKEN=evil\n" + marker + "GITHUB_TOKEN=abc\u{0}",
+                ["GITHUB_TOKEN"],
+                "rc noise before the marker is dropped, even KEY=VALUE-shaped noise"
+            ),
+            (
+                marker + "A_TOKEN=1\u{0}B_KEY=2\u{0}",
+                ["A_TOKEN", "B_KEY"],
+                "several entries"
+            ),
+            (
+                marker + "GITHUB_TOKEN=line1\nline2\u{0}OTHER_KEY=x\u{0}",
+                ["GITHUB_TOKEN", "OTHER_KEY"],
+                "multiline value survives because entries split on NUL, not newline"
+            ),
+            (marker + "no-equals-junk\u{0}REAL_TOKEN=x\u{0}", ["REAL_TOKEN"], "junk without = is skipped"),
+            (marker + "lowercase_var=x\u{0}", [], "lowercase names fail the secret shape"),
+            (marker + "MY-VAR=x\u{0}", [], "hyphens fail the secret shape"),
+            (marker + "PATH=/usr/bin\u{0}", [], "the noise list"),
+            (marker + "CAI_SECRET_FOO=x\u{0}", [], "our own injected namespace never round-trips"),
+            (marker + "DUP_TOKEN=1\u{0}DUP_TOKEN=2\u{0}", ["DUP_TOKEN"], "duplicates collapse to the first"),
+        ]
+
+        for (output, expected, why) in cases {
+            XCTAssertEqual(names(output), expected, why)
+        }
+    }
+
+    func testMultilineValueIsCarriedIntact() throws {
+        let pem = "-----BEGIN KEY-----\nabc\ndef\n-----END KEY-----"
+        let output = marker + "SIGNING_KEY=\(pem)\u{0}"
+        let candidate = try XCTUnwrap(
+            ShellEnvCapture.candidates(fromCaptureOutput: output, existing: []).first
+        )
+        XCTAssertEqual(candidate.value.raw, pem)
+    }
+
+    // MARK: - Filtering and ordering
+
+    func testTokenShapedNamesSortFirst() {
+        let output = marker + "ZEBRA_CONFIG=1\u{0}AWS_KEY=2\u{0}NVM_DIR=3\u{0}GITHUB_TOKEN=4\u{0}"
+        XCTAssertEqual(
+            names(output),
+            ["AWS_KEY", "GITHUB_TOKEN", "NVM_DIR", "ZEBRA_CONFIG"],
+            "token-shaped first, alphabetical within each group"
+        )
+        let candidates = ShellEnvCapture.candidates(fromCaptureOutput: output, existing: [])
+        XCTAssertTrue(candidates[0].looksLikeToken)
+        XCTAssertFalse(candidates[3].looksLikeToken, "ZEBRA_CONFIG collapses under Show all")
+    }
+
+    func testExistingNamesAreMarkedAsReplacements() {
+        let output = marker + "GITHUB_TOKEN=x\u{0}NEW_TOKEN=y\u{0}"
+        let candidates = ShellEnvCapture.candidates(fromCaptureOutput: output, existing: ["GITHUB_TOKEN"])
+        XCTAssertTrue(candidates.first { $0.name == "GITHUB_TOKEN" }?.replacesExisting == true)
+        XCTAssertTrue(candidates.first { $0.name == "NEW_TOKEN" }?.replacesExisting == false)
+    }
+
+    func testValuesNeverLeakThroughDescriptions() {
+        let output = marker + "GITHUB_TOKEN=sk-live-secret-value\u{0}"
+        let candidate = ShellEnvCapture.candidates(fromCaptureOutput: output, existing: []).first!
+        XCTAssertFalse("\(candidate)".contains("sk-live"), "Candidate descriptions must not carry the value")
+    }
+
+    // MARK: - The login shell
+
+    func testLoginShellComesFromTheUserRecordNotTheEnvironment() {
+        let shell = ShellEnvCapture.loginShell()
+        XCTAssertTrue(shell.hasPrefix("/"), "expected an absolute path, got \(shell)")
+    }
+
+    /// One real capture through the user's actual login shell. Pins the whole
+    /// claim: rc noise cannot corrupt the parse, because the marker separates
+    /// it from the `env -0` payload.
+    func testRealCaptureProducesParseableCandidates() async throws {
+        let candidates = try await ShellEnvCapture.capture()
+        // Every candidate that made it through must have a valid name and no
+        // noise-list member.
+        for candidate in candidates {
+            XCTAssertTrue(SecretReference.isValidName(candidate.name), candidate.name)
+            XCTAssertFalse(ShellEnvCapture.noise.contains(candidate.name), candidate.name)
+        }
+    }
+}

--- a/docs/design/DESIGN.md
+++ b/docs/design/DESIGN.md
@@ -78,6 +78,7 @@ Scope of the exception, do not widen it without a design decision:
 1. **`.rounded` design variant for accent numerals only** — keyboard shortcut badges, step counts, standalone result counts ("3 found"). All other labels use default SF Pro. Rounded adds warmth at decision points.
 2. **`.monospacedDigit()` on every runtime-changing number.** Prevents layout jitter when digits change width (1→2→3).
 3. **Never use Dynamic Type.** macOS doesn't support it. All sizes are fixed pt.
+4. **SF Mono for secret names, nowhere else** (added 2026-08-08). A secret name is the exact string typed inside `{{secrets.…}}`, so it renders monospaced (12pt medium) everywhere it appears: Secrets rows, the name field, import candidates, the approval callout, the delete alert. Long names truncate `.middle` with the full name in `.help()`. This is an identifier treatment, not a general label style — do not widen it without a design decision.
 
 ---
 
@@ -199,6 +200,7 @@ Parent shell for Settings sub-screens with a Custom + Built-in pattern. Used by 
 
 - **Header:** `icon · title · subtitle` left, `+` right (only on the Custom tab).
 - **TabBar:** neutral active pill on a recessed neutral track. No indigo (per Indigo discipline). Custom always first, Built-in always second.
+- **Single-list variant** (added 2026-08-08): pass `tabs: []` and the shell renders no TabBar, content directly under the header; `+` shows whenever `onAdd` is set. Used by Secrets.
 - **`+` button trigger:** parent's `+` bumps a UUID `@State` that the child watches via `.onChange(of: externalAddTrigger)` to call `cancelForm() + beginAdding()`. Do NOT use `.id()` on the embed — it remounts the child but `.onChange` won't fire on the freshly-mounted instance. See [`SWIFTUI_GOTCHAS.md`](../../_docs/architecture/SWIFTUI_GOTCHAS.md) for details.
 - **Footer:** single `KeyboardHint(key: "Esc", label: "Back")`.
 
@@ -247,7 +249,7 @@ Multi-line form fields use `MultilineTextEditor` (an `NSTextView` wrapper).
 - **Description:** 11pt, `caiTextSecondary.opacity(0.7)`, centered. Tells the user what the thing IS in plain language.
 - **Optional CTA:** neutral button matching `ChipButton` vocabulary — `caiSurface.opacity(0.6)` fill, hairline border. Usually exposes the most likely next step ("Browse Community Extensions").
 
-**The mental rule:** an empty state is a *welcome*, not an error. Warmth + one clear next step.
+**The mental rule:** an empty state is a *welcome*, not an error. Warmth + one clear next step. One deliberate exception (2026-08-08): the Secrets empty state shows two CTAs (Add a Secret, Import from Shell…) because import only sells itself if it is visible the first time; do not add second CTAs elsewhere without a design decision.
 
 ---
 


### PR DESCRIPTION
Adds a Settings → Secrets screen for tokens stored in the macOS Keychain: add, replace, delete, and import from your login shell. Values are write-only and never rendered again after entry.

Approval sheets now name any secret an action reaches for ("Use your secret NOTION_TOKEN_2"), and connected agents can see secret names (never the values) so they reference the one you actually stored instead of guessing. Name exposure is gated behind the agent-authoring switch.

Notable:
- shell import runs your login shell once, filters to token-shaped names, and falls back to zsh when the login shell rejects the interactive/login flags
- secrets resolve through a CAI_SECRET_* env var so the value never enters the command line; the agent is told to keep {{secrets.NAME}} in double quotes
- empty values are refused; multiline values warn but save intact
Test plan: full suite green; manual QA covered add/replace/delete/import, the approval callout, and the end-to-end agent flow (author, approve, run) plus the kill-switch gating on secret-name exposure.