### PR TITLE
fix: stop sending temperature to OpenAI-compatible models; surface API errors (#52)

### DIFF
--- a/Cai/Cai/Services/LLMService.swift
+++ b/Cai/Cai/Services/LLMService.swift
@@ -557,6 +557,13 @@ actor LLMService {
             if http.statusCode == 401 || http.statusCode == 403 {
                 throw LLMError.serverError(http.statusCode, "Authentication failed — check your API key in Settings → Model Provider.")
             }
+            // Prefer the server's structured error message over the raw JSON body,
+            // reusing the #28 extractor (handles both `{"error":"…"}` and
+            // `{"error":{"message":…}}`). (#52)
+            if let obj = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+               let message = Self.errorMessage(from: obj), !message.isEmpty {
+                throw LLMError.serverError(http.statusCode, message)
+            }
             let body = String(data: data, encoding: .utf8) ?? "Unknown error"
             throw LLMError.serverError(http.statusCode, body)
         }
@@ -762,6 +769,12 @@ actor LLMService {
             if http.statusCode == 401 || http.statusCode == 403 {
                 throw LLMError.serverError(http.statusCode, "Authentication failed — check your API key in Settings → Model Provider.")
             }
+            // Prefer the server's structured error message over the raw JSON body,
+            // reusing the #28 extractor. (#52)
+            if let obj = try? JSONSerialization.jsonObject(with: errorBody) as? [String: Any],
+               let message = Self.errorMessage(from: obj), !message.isEmpty {
+                throw LLMError.serverError(http.statusCode, message)
+            }
             let bodyString = String(data: errorBody, encoding: .utf8) ?? "Unknown error"
             throw LLMError.serverError(http.statusCode, bodyString)
         }
@@ -833,7 +846,10 @@ actor LLMService {
     /// - `.done` for the `data: [DONE]` sentinel.
     /// - `.content(text)` for a content delta.
     ///
-    /// Throws `LLMError.invalidResponse` if a `data:` line carries malformed JSON.
+    /// Throws `LLMError.serverError` if a `data:` line is an OpenAI error event
+    /// (`{"error":{"message":...}}`) — some servers stream errors this way on an
+    /// HTTP 200 instead of a non-200 status (#52). Throws `LLMError.invalidResponse`
+    /// if the payload is neither a chunk nor a recognizable error.
     static func parseSSELine(_ line: String) throws -> SSEParseResult {
         let trimmed = line.trimmingCharacters(in: .whitespaces)
         guard !trimmed.isEmpty else { return .skip }
@@ -847,16 +863,22 @@ actor LLMService {
         guard let data = payload.data(using: .utf8) else {
             throw LLMError.invalidResponse
         }
-        let chunk: OpenAIStreamingChunk
-        do {
-            chunk = try JSONDecoder().decode(OpenAIStreamingChunk.self, from: data)
-        } catch {
-            throw LLMError.invalidResponse
+        // Token-first: the overwhelmingly common case is a content chunk, so try
+        // that decode on the hot path. Only on failure do we check for an error
+        // event — an OpenAI error envelope has no `choices`, so it can't be
+        // mistaken for a chunk. Surfacing `error.message` keeps the real cause
+        // visible instead of a generic "invalid response". (#52)
+        if let chunk = try? JSONDecoder().decode(OpenAIStreamingChunk.self, from: data) {
+            guard let content = chunk.choices.first?.delta.content, !content.isEmpty else {
+                return .skip
+            }
+            return .content(content)
         }
-        guard let content = chunk.choices.first?.delta.content, !content.isEmpty else {
-            return .skip
+        if let obj = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+           let message = Self.errorMessage(from: obj), !message.isEmpty {
+            throw LLMError.serverError(0, message)
         }
-        return .content(content)
+        throw LLMError.invalidResponse
     }
 
     // MARK: - Anthropic (Claude API)
@@ -1155,13 +1177,15 @@ actor LLMService {
 struct ChatRequest: Encodable {
     let model: String
     let messages: [ChatMessage]
-    let temperature: Double
     let max_tokens: Int
     /// nil for non-streaming (key omitted from JSON), `true` for SSE streaming.
     let stream: Bool?
+    // `temperature` is intentionally absent from the wire format (mirrors
+    // `AnthropicRequest`): some OpenAI-compatible models reject the parameter
+    // outright (#52). A future user-facing temperature control re-adds it here.
 
     private enum CodingKeys: String, CodingKey {
-        case model, messages, temperature, max_tokens, stream
+        case model, messages, max_tokens, stream
     }
 
     /// Custom encode so `stream` is omitted from JSON when nil — keeps the
@@ -1170,19 +1194,17 @@ struct ChatRequest: Encodable {
         var c = encoder.container(keyedBy: CodingKeys.self)
         try c.encode(model, forKey: .model)
         try c.encode(messages, forKey: .messages)
-        try c.encode(temperature, forKey: .temperature)
         try c.encode(max_tokens, forKey: .max_tokens)
         try c.encodeIfPresent(stream, forKey: .stream)
     }
 
     /// Build a non-streaming OpenAI-compatible request honoring the caller's `GenerationConfig`.
-    /// Regression guard for #26: temperature and max_tokens must come from `config`,
-    /// not hardcoded at the call site.
+    /// `temperature` is intentionally not sent (see the struct note — #52). Regression
+    /// guard for #26: `max_tokens` must come from `config`, not hardcoded at the call site.
     static func from(config: GenerationConfig, messages: [ChatMessage], model: String) -> ChatRequest {
         ChatRequest(
             model: model,
             messages: messages,
-            temperature: Double(config.temperature),
             max_tokens: config.maxTokens,
             stream: nil
         )
@@ -1194,7 +1216,6 @@ struct ChatRequest: Encodable {
         ChatRequest(
             model: model,
             messages: messages,
-            temperature: Double(config.temperature),
             max_tokens: config.maxTokens,
             stream: true
         )
@@ -1301,7 +1322,9 @@ enum LLMError: LocalizedError {
         case .invalidResponse:
             return "Invalid response from server."
         case .serverError(let code, let body):
-            return "Server error (\(code)): \(body)"
+            // code 0 is the sentinel for a streamed SSE error event, which has no
+            // HTTP status — drop the parenthetical so it reads cleanly. (#52)
+            return code == 0 ? "Server error: \(body)" : "Server error (\(code)): \(body)"
         case .emptyResponse:
             return "Empty response from model."
         case .connectionFailed:

--- a/Cai/Cai/Services/LLMService.swift
+++ b/Cai/Cai/Services/LLMService.swift
@@ -864,20 +864,23 @@ actor LLMService {
             throw LLMError.invalidResponse
         }
         // Token-first: the overwhelmingly common case is a content chunk, so try
-        // that decode on the hot path. Only on failure do we check for an error
-        // event — an OpenAI error envelope has no `choices`, so it can't be
-        // mistaken for a chunk. Surfacing `error.message` keeps the real cause
-        // visible instead of a generic "invalid response". (#52)
-        if let chunk = try? JSONDecoder().decode(OpenAIStreamingChunk.self, from: data) {
-            guard let content = chunk.choices.first?.delta.content, !content.isEmpty else {
-                return .skip
-            }
+        // that decode on the hot path and return as soon as we have visible text. (#52)
+        let chunk = try? JSONDecoder().decode(OpenAIStreamingChunk.self, from: data)
+        if let content = chunk?.choices.first?.delta.content, !content.isEmpty {
             return .content(content)
         }
+        // No usable content. Before treating this as a skip, probe for an error
+        // envelope — some servers stream errors on HTTP 200, occasionally alongside
+        // an empty `choices` array, so the probe must run even when the chunk
+        // decoded. Surfacing `error.message` keeps the real cause visible instead of
+        // a generic "empty response". (#52)
         if let obj = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
            let message = Self.errorMessage(from: obj), !message.isEmpty {
             throw LLMError.serverError(0, message)
         }
+        // A decodable-but-contentless chunk (role-only / tool-only / empty choices /
+        // null content) is a legitimate skip; anything else is malformed.
+        if chunk != nil { return .skip }
         throw LLMError.invalidResponse
     }
 

--- a/Cai/CaiTests/LLMServiceTests.swift
+++ b/Cai/CaiTests/LLMServiceTests.swift
@@ -415,11 +415,13 @@ final class LLMServiceTests: XCTestCase {
 
     // MARK: - Cloud (OpenAI-compatible) Request Types
 
-    func testChatRequestFromConfigForwardsTemperatureAndMaxTokens() throws {
-        // Regression guard for #26 (https://github.com/cai-layer/cai/issues/26).
-        // The cloud OpenAI-compatible branch previously hardcoded
-        // temperature: 0.3 and max_tokens: 1024 instead of using the caller's
-        // GenerationConfig. The factory must forward both values verbatim.
+    func testChatRequestFromConfigForwardsMaxTokensAndOmitsTemperature() throws {
+        // Regression guard for #26 (https://github.com/cai-layer/cai/issues/26):
+        // the cloud branch previously hardcoded max_tokens: 1024 instead of using
+        // the caller's GenerationConfig — max_tokens must be forwarded verbatim.
+        // #52: temperature must NOT be sent — some OpenAI-compatible models reject
+        // it (mirrors the Anthropic path, which also omits it), even though the
+        // config still carries a temperature for the built-in MLX path.
         let config = GenerationConfig(
             temperature: 0.7,
             topP: 0.9,
@@ -429,20 +431,21 @@ final class LLMServiceTests: XCTestCase {
         let messages = [ChatMessage(role: "user", content: "Hello")]
 
         let request = ChatRequest.from(config: config, messages: messages, model: "openrouter/auto")
+        let json = try JSONSerialization.jsonObject(with: JSONEncoder().encode(request)) as! [String: Any]
 
         XCTAssertEqual(request.model, "openrouter/auto")
-        XCTAssertEqual(request.temperature, 0.7, accuracy: 0.0001,
-                       "temperature must come from config, not hardcoded")
-        XCTAssertEqual(request.max_tokens, 4096,
-                       "max_tokens must come from config, not hardcoded")
+        XCTAssertNil(json["temperature"],
+                     "temperature must not be sent (#52) even though config carries 0.7")
+        XCTAssertEqual(json["max_tokens"] as? Int, 4096,
+                       "max_tokens must come from config, not hardcoded (#26)")
         XCTAssertEqual(request.messages.count, 1)
         XCTAssertEqual(request.messages.first?.role, "user")
     }
 
     func testChatRequestFromConfigUsesProofreadActionDefaults() throws {
         // Verifies the factory composes correctly with GenerationConfig.forAction().
-        // Pre-fix, this combination would have been silently downgraded to
-        // temperature: 0.3 / max_tokens: 1024 on the cloud path.
+        // Pre-#26, max_tokens would have been silently downgraded to 1024 on the
+        // cloud path. (temperature is no longer sent — see #52.)
         let config = GenerationConfig.forAction(.proofread)
         let request = ChatRequest.from(
             config: config,
@@ -450,7 +453,6 @@ final class LLMServiceTests: XCTestCase {
             model: "google/gemini-2.5-flash"
         )
 
-        XCTAssertEqual(request.temperature, 0.0, accuracy: 0.0001)
         XCTAssertEqual(request.max_tokens, 16384,
                        ".proofread maxTokens must reach the cloud request")
     }
@@ -465,7 +467,6 @@ final class LLMServiceTests: XCTestCase {
                 ChatMessage(role: "system", content: "You are helpful."),
                 ChatMessage(role: "user", content: "Hi"),
             ],
-            temperature: 0.5,
             max_tokens: 2048,
             stream: nil
         )
@@ -475,10 +476,8 @@ final class LLMServiceTests: XCTestCase {
 
         XCTAssertEqual(json["model"] as? String, "test-model")
         XCTAssertEqual(json["max_tokens"] as? Int, 2048)
-        // temperature is Double in the struct — encoded as a JSON number
-        let temperature = json["temperature"] as? Double
-        XCTAssertNotNil(temperature)
-        XCTAssertEqual(temperature ?? -1, 0.5, accuracy: 0.0001)
+        XCTAssertNil(json["temperature"],
+                     "temperature must not be sent to OpenAI-compatible endpoints (#52)")
 
         let messages = json["messages"] as! [[String: Any]]
         XCTAssertEqual(messages.count, 2)
@@ -508,6 +507,8 @@ final class LLMServiceTests: XCTestCase {
         // Other fields still forwarded (regression guard for #26 continues to apply).
         XCTAssertEqual(json["max_tokens"] as? Int, 16384)
         XCTAssertEqual(json["model"] as? String, "openrouter/auto")
+        XCTAssertNil(json["temperature"],
+                     "streaming requests must not send temperature (#52)")
     }
 
     func testChatRequestFromOmitsStreamKey() throws {
@@ -606,6 +607,42 @@ final class LLMServiceTests: XCTestCase {
         let line = #"data: {"choices":[]}"#
         let result = try LLMService.parseSSELine(line)
         XCTAssertEqual(result, .skip)
+    }
+
+    func testParseSSELineSurfacesObjectErrorEvent() {
+        // #52: some OpenAI-compatible servers stream a rejection as an SSE error
+        // event on an HTTP 200 (e.g. a model that rejects `temperature`). The parser
+        // must surface the real message instead of a generic "invalid response".
+        let line = #"data: {"error":{"message":"Unsupported parameter: temperature","type":"invalid_request_error"}}"#
+        XCTAssertThrowsError(try LLMService.parseSSELine(line)) { error in
+            guard case let LLMError.serverError(_, message) = error else {
+                return XCTFail("expected LLMError.serverError, got \(error)")
+            }
+            XCTAssertEqual(message, "Unsupported parameter: temperature")
+        }
+    }
+
+    func testParseSSELineSurfacesStringErrorEvent() {
+        // The LM Studio shape — {"error": "..."} as a bare string. errorMessage(from:)
+        // handles both forms, so this must surface too.
+        let line = #"data: {"error":"model is overloaded"}"#
+        XCTAssertThrowsError(try LLMService.parseSSELine(line)) { error in
+            guard case let LLMError.serverError(_, message) = error else {
+                return XCTFail("expected LLMError.serverError, got \(error)")
+            }
+            XCTAssertEqual(message, "model is overloaded")
+        }
+    }
+
+    func testParseSSELineErrorEventWithoutMessageDoesNotSurfaceBlank() {
+        // An error object with no usable message must not surface a blank
+        // "Server error:" — fall through to invalidResponse instead.
+        let line = #"data: {"error":{"type":"invalid_request_error"}}"#
+        XCTAssertThrowsError(try LLMService.parseSSELine(line)) { error in
+            guard case LLMError.invalidResponse = error else {
+                return XCTFail("expected LLMError.invalidResponse, got \(error)")
+            }
+        }
     }
 
     // MARK: - Endpoint Normalization (issue #28)

--- a/Cai/CaiTests/LLMServiceTests.swift
+++ b/Cai/CaiTests/LLMServiceTests.swift
@@ -645,6 +645,20 @@ final class LLMServiceTests: XCTestCase {
         }
     }
 
+    func testParseSSELineSurfacesErrorEventAlongsideEmptyChoices() {
+        // #52: a chunk that decodes (empty `choices`) but also carries an `error`
+        // must surface the error, not skip. Token-first decode succeeds here, so the
+        // error probe has to run even on a decodable-but-contentless chunk — otherwise
+        // the real cause is swallowed and the user sees a generic "empty response".
+        let line = #"data: {"choices":[],"error":{"message":"model overloaded"}}"#
+        XCTAssertThrowsError(try LLMService.parseSSELine(line)) { error in
+            guard case let LLMError.serverError(_, message) = error else {
+                return XCTFail("expected LLMError.serverError, got \(error)")
+            }
+            XCTAssertEqual(message, "model overloaded")
+        }
+    }
+
     // MARK: - Endpoint Normalization (issue #28)
 
     // The endpoint field is a base URL we append `/v1/...` onto. Users paste a


### PR DESCRIPTION
Some OpenAI-compatible models (e.g. gpt-5.x) reject `temperature` and failed on every request, and the streamed rejection was hidden behind a generic "Invalid response from server."

Stop sending `temperature` on the OpenAI-compatible path (mirrors `AnthropicRequest`, which already omits it; the built-in MLX path still uses it). Surface the server's real error message — via the existing `errorMessage(from:)` extractor — on non-streaming 4xx/5xx and on error events streamed on an HTTP 200.

Test plan: `LLMServiceTests` all green (new SSE error-shape + temperature-absent coverage). Verified in-app against live OpenRouter (happy path + real 400 error) and a local mock streaming an error on HTTP 200 → "Server error: Unsupported parameter: temperature", with no `temperature` on the wire.
Fixes #52
